### PR TITLE
Remove intermediary buffer in decode_mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,60 +213,67 @@ pub fn encode_mode(bytes: &[u8], mode: Base64Mode) -> String {
 ///}
 ///```
 pub fn decode_mode(input: &str, mode: Base64Mode) -> Result<Vec<u8>, Base64Error> {
-    let bytes = input.as_bytes();
-
     let (ref charset, _) = match mode {
         Base64Mode::Standard => (STANDARD, false),
         Base64Mode::UrlSafe => (URL_SAFE, false),
         //TODO Base64Mode::MIME => (STANDARD, true)
     };
-
     let (penult_byte, ult_byte) = (charset[62], charset[63]);
 
-    let mut buffer = Vec::<u8>::with_capacity(bytes.len());
-
-    for i in 0..bytes.len() {
-        if bytes[i] > 0x40 && bytes[i] < 0x5b {
-            buffer.push(bytes[i] - 0x41);
-        } else if bytes[i] > 0x60 && bytes[i] < 0x7b {
-            buffer.push(bytes[i] - 0x61 + 0x1a);
-        } else if bytes[i] > 0x2f && bytes[i] < 0x3a {
-            buffer.push(bytes[i] - 0x30 + 0x34);
-        } else if bytes[i] == penult_byte {
-            buffer.push(0x3e);
-        } else if bytes[i] == ult_byte {
-            buffer.push(0x3f);
-        } else if bytes[i] == 0x3d {
-            ;
-        } else {
-            return Err(Base64Error::InvalidByte(i, bytes[i]));
+    let convert = |byte: &u8| ->  Option<Result<u8, Base64Error>> {
+        if byte > &0x40 && byte < &0x5b {
+            Some(Ok(byte - &0x41))
+        } else if byte > &0x60 && byte < &0x7b {
+            Some(Ok(byte - &0x61 + &0x1a))
+        } else if byte > &0x2f && byte < &0x3a {
+            Some(Ok(byte - &0x30 + &0x34))
+        } else if byte == &penult_byte {
+            Some(Ok(0x3e))
+        } else if byte == &ult_byte {
+            Some(Ok(0x3f))
+        }  else if byte == &0x3d {
+            None
         }
-    }
+        else {
+            Some(Err(Base64Error::InvalidByte(0, *byte)))
+        }
+    };
+    let bytes = input.as_bytes();
+    let bytes_len = bytes.iter().filter(|byte| {**byte != 0x3d}).count();
+    let mut bytes = bytes.iter().filter_map(convert);
 
-    let rem = buffer.len() % 4;
 
-    if rem == 1 {
-        return Err(Base64Error::InvalidLength);
-    }
-
-    let div = buffer.len() - rem;
-
-    let mut raw = Vec::<u8>::with_capacity(3*div/4 + rem);
-    let mut i = 0;
-
-    while i < div {
-        raw.push(buffer[i] << 2 | buffer[i+1] >> 4);
-        raw.push(buffer[i+1] << 4 | buffer[i+2] >> 2);
-        raw.push(buffer[i+2] << 6 | buffer[i+3]);
-
-        i+=4;
-    }
-
-    if rem > 1 {
-        raw.push(buffer[div] << 2 | buffer[div+1] >> 4);
-    }
-    if rem > 2 {
-        raw.push(buffer[div+1] << 4 | buffer[div+2] >> 2);
+    let mut raw = Vec::<u8>::with_capacity((3*bytes_len + 3)/4);
+    let mut out_byte:u8;
+    loop {
+        //println!("i: {}", i);
+        if let Some(in_byte) = bytes.next() {
+            let in_byte = try!(in_byte);
+            out_byte = in_byte << 2;
+        } else {
+            break
+        }
+        if let Some(in_byte) = bytes.next() {
+            let in_byte = try!(in_byte);
+            out_byte |= in_byte >> 4;
+            raw.push(out_byte);
+            out_byte = in_byte << 4;
+        } else {
+            return Err(Base64Error::InvalidLength)
+        }
+        if let Some(in_byte) = bytes.next() {
+            let in_byte = try!(in_byte);
+            out_byte |= in_byte >> 2;
+            raw.push(out_byte);
+            out_byte = in_byte << 6;
+        } else {
+            break;
+        }
+        if let Some(in_byte) = bytes.next() {
+            let in_byte = try!(in_byte);
+            out_byte |= in_byte;
+            raw.push(out_byte);
+        }
     }
 
     Ok(raw)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub fn decode_mode(input: &str, mode: Base64Mode) -> Result<Vec<u8>, Base64Error
     };
     let (penult_byte, ult_byte) = (charset[62], charset[63]);
 
-    let convert = |byte: &u8| ->  Option<Result<u8, Base64Error>> {
+    let convert = |(index, byte): (usize, &u8)| ->  Option<Result<u8, Base64Error>> {
         if byte > &0x40 && byte < &0x5b {
             Some(Ok(byte - &0x41))
         } else if byte > &0x60 && byte < &0x7b {
@@ -235,18 +235,16 @@ pub fn decode_mode(input: &str, mode: Base64Mode) -> Result<Vec<u8>, Base64Error
             None
         }
         else {
-            Some(Err(Base64Error::InvalidByte(0, *byte)))
+            Some(Err(Base64Error::InvalidByte(index, *byte)))
         }
     };
     let bytes = input.as_bytes();
     let bytes_len = bytes.iter().filter(|byte| {**byte != 0x3d}).count();
-    let mut bytes = bytes.iter().filter_map(convert);
-
+    let mut bytes = bytes.iter().enumerate().filter_map(convert);
 
     let mut raw = Vec::<u8>::with_capacity((3*bytes_len + 3)/4);
     let mut out_byte:u8;
     loop {
-        //println!("i: {}", i);
         if let Some(in_byte) = bytes.next() {
             let in_byte = try!(in_byte);
             out_byte = in_byte << 2;


### PR DESCRIPTION
I wanted to get rid of the `buffer` variable in `decode_mode`, since it was an unnecessary memory allocation, but I got a little overexcited and reworked the method to use entirely iterators instead.

If you have any stylistic or naming concerns, I am happy to address them.
