### PR TITLE
Add encoding category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/alicemaz/rust-base64"
 documentation = "https://github.com/alicemaz/rust-base64/blob/master/README.md"
 readme = "README.md"
 keywords = ["base64", "utf8", "encode", "decode"]
+categories = ["encoding"]
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
Add this crate to the `encoding` [category](http://integer32.com/2017/01/20/categories-and-ci-badges.html). Needs nightly cargo at the moment.