### PR TITLE
Eliminate unused error variant and rename to DecodeError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,44 +30,32 @@ pub static URL_SAFE_NO_PAD: Config = Config {char_set: CharacterSet::UrlSafe, pa
 
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum Base64Error {
-    Utf8(str::Utf8Error),
+pub enum DecodeError {
     InvalidByte(usize, u8),
     InvalidLength,
 }
 
-impl fmt::Display for Base64Error {
+impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Base64Error::Utf8(ref err) => err.fmt(f),
-            Base64Error::InvalidByte(index, byte) =>
+            DecodeError::InvalidByte(index, byte) =>
                 write!(f, "Invalid byte {}, offset {}.", byte, index),
-            Base64Error::InvalidLength =>
+            DecodeError::InvalidLength =>
                 write!(f, "Encoded text cannot have a 6-bit remainder.")
         }
     }
 }
 
-impl error::Error for Base64Error {
+impl error::Error for DecodeError {
     fn description(&self) -> &str {
         match *self {
-            Base64Error::Utf8(ref err) => err.description(),
-            Base64Error::InvalidByte(_,_) => "invalid byte",
-            Base64Error::InvalidLength => "invalid length"
+            DecodeError::InvalidByte(_, _) => "invalid byte",
+            DecodeError::InvalidLength => "invalid length"
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            Base64Error::Utf8(ref err) => Some(err as &error::Error),
-            _ => None
-        }
-    }
-}
-
-impl From<str::Utf8Error> for Base64Error {
-    fn from(err: str::Utf8Error) -> Base64Error {
-        Base64Error::Utf8(err)
+        None
     }
 }
 
@@ -103,7 +91,7 @@ pub fn encode(input: &[u8]) -> String {
 ///    println!("{:?}", bytes);
 ///}
 ///```
-pub fn decode(input: &str) -> Result<Vec<u8>, Base64Error> {
+pub fn decode(input: &str) -> Result<Vec<u8>, DecodeError> {
     decode_config(input, STANDARD)
 }
 
@@ -123,7 +111,7 @@ pub fn decode(input: &str) -> Result<Vec<u8>, Base64Error> {
 ///    println!("{:?}", bytes);
 ///}
 ///```
-pub fn decode_ws(input: &str) -> Result<Vec<u8>, Base64Error> {
+pub fn decode_ws(input: &str) -> Result<Vec<u8>, DecodeError> {
     let mut raw = Vec::<u8>::with_capacity(input.len());
     raw.extend(input.bytes().filter(|b| !b" \n\t\r\x0c".contains(b)));
 
@@ -285,7 +273,7 @@ pub fn encode_config_buf(input: &[u8], config: Config, buf: &mut String) {
 ///    println!("{:?}", bytes_url);
 ///}
 ///```
-pub fn decode_config(input: &str, config: Config) -> Result<Vec<u8>, Base64Error> {
+pub fn decode_config(input: &str, config: Config) -> Result<Vec<u8>, DecodeError> {
     let mut buffer = Vec::<u8>::with_capacity(input.len() * 4 / 3);
 
     decode_config_buf(input, config, &mut buffer).map(|_| buffer)
@@ -311,7 +299,7 @@ pub fn decode_config(input: &str, config: Config) -> Result<Vec<u8>, Base64Error
 ///    println!("{:?}", buffer);
 ///}
 ///```
-pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> Result<(), Base64Error> {
+pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> Result<(), DecodeError> {
     let ref decode_table = match config.char_set {
         CharacterSet::Standard => tables::STANDARD_DECODE,
         CharacterSet::UrlSafe => tables::URL_SAFE_DECODE,
@@ -422,7 +410,7 @@ pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> R
 
         if morsel == tables::INVALID_VALUE {
             // we got here from a break
-            return Err(Base64Error::InvalidByte(bad_byte_index, input_bytes[bad_byte_index]));
+            return Err(DecodeError::InvalidByte(bad_byte_index, input_bytes[bad_byte_index]));
         }
     }
 
@@ -453,7 +441,7 @@ pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> R
             if i % 4 < 2 {
                 // Check for case #2.
                 // TODO InvalidPadding error
-                return Err(Base64Error::InvalidByte(length_of_full_chunks + i, *b));
+                return Err(DecodeError::InvalidByte(length_of_full_chunks + i, *b));
             };
 
             if padding_bytes == 0 {
@@ -469,7 +457,7 @@ pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> R
         // non-suffix '=' in trailing chunk either. Report error as first
         // erroneous padding.
         if padding_bytes > 0 {
-            return Err(Base64Error::InvalidByte(
+            return Err(DecodeError::InvalidByte(
                 length_of_full_chunks + first_padding_index, 0x3D));
         };
 
@@ -479,7 +467,7 @@ pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> R
         // tables are all 256 elements, cannot overflow from a u8 index
         let morsel = decode_table[*b as usize];
         if morsel == tables::INVALID_VALUE {
-            return Err(Base64Error::InvalidByte(length_of_full_chunks + i, *b));
+            return Err(DecodeError::InvalidByte(length_of_full_chunks + i, *b));
         };
 
         leftover_bits |= (morsel as u64) << shift;
@@ -488,11 +476,11 @@ pub fn decode_config_buf(input: &str, config: Config, buffer: &mut Vec<u8>) -> R
 
     let leftover_bits_ready_to_append = match morsels_in_leftover {
         0 => 0,
-        1 => return Err(Base64Error::InvalidLength),
+        1 => return Err(DecodeError::InvalidLength),
         2 => 8,
         3 => 16,
         4 => 24,
-        5 => return Err(Base64Error::InvalidLength),
+        5 => return Err(DecodeError::InvalidLength),
         6 => 32,
         7 => 40,
         8 => 48,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -195,7 +195,7 @@ fn decode_rfc4648_6() {
 fn decode_pad_inside_fast_loop_chunk_error() {
     // can't PartialEq Base64Error, so we do this the hard way
     match decode("YWxpY2U=====").unwrap_err() {
-        Base64Error::InvalidByte(offset, byte) => {
+        DecodeError::InvalidByte(offset, byte) => {
             // since the first 8 bytes are handled in the fast loop, the
             // padding is an error. Could argue that the *next* padding
             // byte is technically the first erroneous one, but reporting
@@ -210,7 +210,7 @@ fn decode_pad_inside_fast_loop_chunk_error() {
 #[test]
 fn decode_extra_pad_after_fast_loop_chunk_error() {
     match decode("YWxpY2UABB===").unwrap_err() {
-        Base64Error::InvalidByte(offset, byte) => {
+        DecodeError::InvalidByte(offset, byte) => {
             // extraneous third padding byte
             assert_eq!(12, offset);
             assert_eq!(0x3D, byte);
@@ -224,7 +224,7 @@ fn decode_extra_pad_after_fast_loop_chunk_error() {
 #[test]
 fn decode_absurd_pad_error() {
     match decode("==Y=Wx===pY=2U=====").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             assert_eq!(0, size);
             assert_eq!(0x3D, byte);
         }
@@ -235,7 +235,7 @@ fn decode_absurd_pad_error() {
 #[test]
 fn decode_starts_with_padding_single_quad_error() {
     match decode("====").unwrap_err() {
-        Base64Error::InvalidByte(offset, byte) => {
+        DecodeError::InvalidByte(offset, byte) => {
             // with no real input, first padding byte is bogus
             assert_eq!(0, offset);
             assert_eq!(0x3D, byte);
@@ -247,7 +247,7 @@ fn decode_starts_with_padding_single_quad_error() {
 #[test]
 fn decode_extra_padding_in_trailing_quad_returns_error() {
     match decode("zzz==").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             // first unneeded padding byte
             assert_eq!(4, size);
             assert_eq!(0x3D, byte);
@@ -259,7 +259,7 @@ fn decode_extra_padding_in_trailing_quad_returns_error() {
 #[test]
 fn decode_extra_padding_in_trailing_quad_2_returns_error() {
     match decode("zz===").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             // first unneeded padding byte
             assert_eq!(4, size);
             assert_eq!(0x3D, byte);
@@ -272,7 +272,7 @@ fn decode_extra_padding_in_trailing_quad_2_returns_error() {
 #[test]
 fn decode_start_second_quad_with_padding_returns_error() {
     match decode("zzzz=").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             // first unneeded padding byte
             assert_eq!(4, size);
             assert_eq!(0x3D, byte);
@@ -284,7 +284,7 @@ fn decode_start_second_quad_with_padding_returns_error() {
 #[test]
 fn decode_padding_in_last_quad_followed_by_non_padding_returns_error() {
     match decode("zzzz==z").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             assert_eq!(4, size);
             assert_eq!(0x3D, byte);
         }
@@ -295,7 +295,7 @@ fn decode_padding_in_last_quad_followed_by_non_padding_returns_error() {
 #[test]
 fn decode_too_short_with_padding_error() {
     match decode("z==").unwrap_err() {
-        Base64Error::InvalidByte(size, byte) => {
+        DecodeError::InvalidByte(size, byte) => {
             // first unneeded padding byte
             assert_eq!(1, size);
             assert_eq!(0x3D, byte);
@@ -307,7 +307,7 @@ fn decode_too_short_with_padding_error() {
 #[test]
 fn decode_too_short_without_padding_error() {
     match decode("z").unwrap_err() {
-        Base64Error::InvalidLength => {}
+        DecodeError::InvalidLength => {}
         _ => assert!(false)
     }
 }
@@ -315,7 +315,7 @@ fn decode_too_short_without_padding_error() {
 #[test]
 fn decode_too_short_second_quad_without_padding_error() {
     match decode("zzzzX").unwrap_err() {
-        Base64Error::InvalidLength => {}
+        DecodeError::InvalidLength => {}
         _ => assert!(false)
     }
 }
@@ -332,7 +332,7 @@ fn decode_error_for_bogus_char_in_right_position() {
                 "length {} error position {}", length, error_position);
 
             match decode(&input).unwrap_err() {
-                Base64Error::InvalidByte(size, byte) => {
+                DecodeError::InvalidByte(size, byte) => {
                     assert_eq!(error_position, size,
                         "length {} error position {}", length, error_position);
                     assert_eq!(0x25, byte);


### PR DESCRIPTION
I tried out what I was musing about in https://github.com/alicemaz/rust-base64/pull/14#discussion_r100730417 and sure enough, `Utf8Error` is unused.

Once that was removed, all that's left are errors specific to decoding, so I renamed the enum. I'm open to other naming ideas, but I think it's clearer for the user browsing the docs to be able to see "Ah, this is all the things that can go wrong decoding". This naming also encourages us to put future errors that aren't for decoding, should we ever have any, into a separate type so that the compiler's exhaustive match checking is maximally helpful for users who actually do care about the variants of error enums.