### PR TITLE
Minimize unsafe usage and rework line wrapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 
 [dependencies]
 byteorder = "1.0.0"
+num = "0.1.37"
 
 [dev-dependencies]
 rand = "=0.3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 byteorder = "1.0.0"
-num = "0.1.37"
+safemem = "0.2.0"
 
 [dev-dependencies]
 rand = "=0.3.15"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -224,8 +224,7 @@ fn do_encode_bench_reuse_buf(b: &mut Bencher, size: usize, config: Config) {
 
     b.bytes = v.len() as u64;
     b.iter(|| {
-        let e = encode_config_buf(&v, config, &mut buf);
-        test::black_box(&e);
+        encode_config_buf(&v, config, &mut buf);
         buf.clear();
     });
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,7 +4,7 @@ extern crate base64;
 extern crate test;
 extern crate rand;
 
-use base64::{decode, decode_config_buf, encode, encode_config_buf, STANDARD};
+use base64::{decode, decode_config_buf, encode, encode_config_buf, Config, MIME, STANDARD};
 
 use test::Bencher;
 use rand::Rng;
@@ -16,7 +16,7 @@ fn encode_3b(b: &mut Bencher) {
 
 #[bench]
 fn encode_3b_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 3)
+    do_encode_bench_reuse_buf(b, 3, STANDARD)
 }
 
 #[bench]
@@ -26,7 +26,7 @@ fn encode_50b(b: &mut Bencher) {
 
 #[bench]
 fn encode_50b_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 50)
+    do_encode_bench_reuse_buf(b, 50, STANDARD)
 }
 
 #[bench]
@@ -36,7 +36,7 @@ fn encode_100b(b: &mut Bencher) {
 
 #[bench]
 fn encode_100b_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 100)
+    do_encode_bench_reuse_buf(b, 100, STANDARD)
 }
 
 #[bench]
@@ -46,7 +46,12 @@ fn encode_500b(b: &mut Bencher) {
 
 #[bench]
 fn encode_500b_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 500)
+    do_encode_bench_reuse_buf(b, 500, STANDARD)
+}
+
+#[bench]
+fn encode_500b_reuse_buf_mime(b: &mut Bencher) {
+    do_encode_bench_reuse_buf(b, 500, MIME)
 }
 
 #[bench]
@@ -56,7 +61,12 @@ fn encode_3kib(b: &mut Bencher) {
 
 #[bench]
 fn encode_3kib_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 3 * 1024)
+    do_encode_bench_reuse_buf(b, 3 * 1024, STANDARD)
+}
+
+#[bench]
+fn encode_3kib_reuse_buf_mime(b: &mut Bencher) {
+    do_encode_bench_reuse_buf(b, 3 * 1024, MIME)
 }
 
 #[bench]
@@ -66,7 +76,7 @@ fn encode_3mib(b: &mut Bencher) {
 
 #[bench]
 fn encode_3mib_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 3 * 1024 * 1024)
+    do_encode_bench_reuse_buf(b, 3 * 1024 * 1024, STANDARD)
 }
 
 #[bench]
@@ -76,7 +86,7 @@ fn encode_10mib(b: &mut Bencher) {
 
 #[bench]
 fn encode_10mib_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 10 * 1024 * 1024)
+    do_encode_bench_reuse_buf(b, 10 * 1024 * 1024, STANDARD)
 }
 
 #[bench]
@@ -86,7 +96,7 @@ fn encode_30mib(b: &mut Bencher) {
 
 #[bench]
 fn encode_30mib_reuse_buf(b: &mut Bencher) {
-    do_encode_bench_reuse_buf(b, 30 * 1024 * 1024)
+    do_encode_bench_reuse_buf(b, 30 * 1024 * 1024, STANDARD)
 }
 
 #[bench]
@@ -206,7 +216,7 @@ fn do_encode_bench(b: &mut Bencher, size: usize) {
     });
 }
 
-fn do_encode_bench_reuse_buf(b: &mut Bencher, size: usize) {
+fn do_encode_bench_reuse_buf(b: &mut Bencher, size: usize, config: Config) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
 
@@ -214,7 +224,7 @@ fn do_encode_bench_reuse_buf(b: &mut Bencher, size: usize) {
 
     b.bytes = v.len() as u64;
     b.iter(|| {
-        let e = encode_config_buf(&v, STANDARD, &mut buf);
+        let e = encode_config_buf(&v, config, &mut buf);
         test::black_box(&e);
         buf.clear();
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 extern crate byteorder;
 
-use std::{fmt, error, str};
+use std::{fmt, error, ptr, str};
 
 use byteorder::{BigEndian, ByteOrder};
 
 mod tables;
+
+mod line_wrap;
+use line_wrap::{line_wrap_parameters, line_wrap};
 
 /// Available encoding character sets
 #[derive(Clone, Copy, Debug)]
@@ -15,15 +18,41 @@ pub enum CharacterSet {
     UrlSafe
 }
 
+impl CharacterSet {
+    fn encode_table(&self) -> &'static [u8; 64] {
+        match self {
+            &CharacterSet::Standard => tables::STANDARD_ENCODE,
+            &CharacterSet::UrlSafe => tables::URL_SAFE_ENCODE
+        }
+    }
+
+    fn decode_table(&self) -> &'static [u8; 256] {
+        match self {
+            &CharacterSet::Standard => tables::STANDARD_DECODE,
+            &CharacterSet::UrlSafe => tables::URL_SAFE_DECODE
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum LineEnding {
     LF,
     CRLF,
 }
 
+impl LineEnding {
+    fn len(&self) -> usize {
+        match self {
+            &LineEnding::LF => 1,
+            &LineEnding::CRLF => 2
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum LineWrap {
     NoWrap,
+    // wrap length is always > 0
     Wrap(usize, LineEnding)
 }
 
@@ -171,7 +200,7 @@ pub fn decode<T: ?Sized + AsRef<[u8]>>(input: &T) -> Result<Vec<u8>, DecodeError
 ///}
 ///```
 pub fn encode_config<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config) -> String {
-    let mut buf = String::with_capacity(encoded_size(input.as_ref().len(), config));
+    let mut buf = String::with_capacity(encoded_size(input.as_ref().len(), &config));
 
     encode_config_buf(input, config, &mut buf);
 
@@ -179,23 +208,34 @@ pub fn encode_config<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config) -> Stri
 }
 
 /// calculate the base64 encoded string size, including padding
-fn encoded_size(bytes_len: usize, config: Config) -> usize {
+fn encoded_size(bytes_len: usize, config: &Config) -> usize {
+    let msg = "Encoded size exceeds usize";
     let rem = bytes_len % 3;
 
     let complete_input_chunks = bytes_len / 3;
-    let complete_output_chars = complete_input_chunks * 4;
-    let printing_output_chars = if rem == 0 {
-        complete_output_chars
+    let complete_chunk_output = complete_input_chunks.checked_mul(4).expect(msg);
+
+    let encoded_len_no_wrap = if rem > 0 {
+        if config.pad {
+            complete_chunk_output.checked_add(4).expect(msg)
+        } else {
+            let encoded_rem = match rem {
+                1 => 2,
+                2 => 3,
+                _ => panic!("Impossible remainder")
+            };
+            complete_chunk_output.checked_add(encoded_rem).expect(msg)
+        }
     } else {
-        complete_output_chars + 4
-    };
-    let line_ending_output_chars = match config.line_wrap {
-        LineWrap::NoWrap => 0,
-        LineWrap::Wrap(n, LineEnding::CRLF) => printing_output_chars / n * 2,
-        LineWrap::Wrap(n, LineEnding::LF) => printing_output_chars / n,
+        complete_chunk_output
     };
 
-    return printing_output_chars + line_ending_output_chars;
+    match config.line_wrap {
+        LineWrap::NoWrap => encoded_len_no_wrap,
+        LineWrap::Wrap(line_len, line_ending) => {
+            line_wrap_parameters(encoded_len_no_wrap, line_len, line_ending).total_len
+        }
+    }
 }
 
 ///Encode arbitrary octets as base64.
@@ -218,105 +258,140 @@ fn encoded_size(bytes_len: usize, config: Config) -> usize {
 ///```
 pub fn encode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config, buf: &mut String) {
     let input_bytes = input.as_ref();
-    let ref charset = match config.char_set {
-        CharacterSet::Standard => tables::STANDARD_ENCODE,
-        CharacterSet::UrlSafe => tables::URL_SAFE_ENCODE,
-    };
 
     // reserve to make sure the memory we'll be writing to with unsafe is allocated
-    buf.reserve(encoded_size(input_bytes.len(), config));
+    let encoded_size = encoded_size(input_bytes.len(), &config);
+    buf.reserve(encoded_size);
 
     let orig_buf_len = buf.len();
-    let mut fast_loop_output_buf_len = orig_buf_len;
-
-    let input_chunk_len = 6;
-
-    let last_fast_index = input_bytes.len().saturating_sub(8);
 
     // we're only going to insert valid utf8
-    let mut raw = unsafe { buf.as_mut_vec() };
-    // start at the first free part of the output buf
-    let mut output_ptr = unsafe { raw.as_mut_ptr().offset(orig_buf_len as isize) };
+    let mut buf_bytes;
+    unsafe {
+        buf_bytes = buf.as_mut_vec();
+        // expand the string's vec to use its reserved size
+        buf_bytes.set_len(orig_buf_len + encoded_size);
+    }
+
+    let output_bytes_written = {
+        let mut b64_output = &mut buf_bytes[orig_buf_len..];
+
+        // write into the newly reserved space
+        let b64_bytes_written = encode_to_slice(input_bytes, b64_output,
+                                                    config.char_set.encode_table());
+
+        let padding_bytes = if config.pad {
+            add_padding(input_bytes.len(), &mut b64_output[b64_bytes_written..])
+        } else {
+            0
+        };
+
+        let wrappable_bytes = b64_bytes_written + padding_bytes;
+
+        let line_ending_bytes = match config.line_wrap {
+            LineWrap::Wrap(line_len, line_end) =>
+                line_wrap(b64_output, wrappable_bytes, line_len, line_end),
+            LineWrap::NoWrap => 0
+        };
+
+        wrappable_bytes + line_ending_bytes
+    };
+
+    unsafe {
+        buf_bytes.set_len(orig_buf_len + output_bytes_written);
+    }
+}
+
+/// Encode input bytes to utf8 base64 bytes. Does not pad or line wrap.
+/// `output` must be long enough to hold the encoded `input` without padding or line wrapping.
+/// Returns the number of bytes written.
+#[inline]
+fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> usize {
     let mut input_index: usize = 0;
-    if input_bytes.len() >= 8 {
+    let mut output_ptr = output.as_mut_ptr();
+
+    let last_fast_index = input.len().saturating_sub(8);
+    let fast_chunk_len = 6;
+
+    if last_fast_index > 0 {
         while input_index <= last_fast_index {
-            let input_chunk = BigEndian::read_u64(&input_bytes[input_index..(input_index + 8)]);
+            let input_chunk = BigEndian::read_u64(&input[input_index..(input_index + 8)]);
 
             // strip off 6 bits at a time for the first 6 bytes
             unsafe {
-                std::ptr::write(output_ptr, charset[((input_chunk >> 58) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(1), charset[((input_chunk >> 52) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(2), charset[((input_chunk >> 46) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(3), charset[((input_chunk >> 40) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(4), charset[((input_chunk >> 34) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(5), charset[((input_chunk >> 28) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(6), charset[((input_chunk >> 22) & 0x3F) as usize]);
-                std::ptr::write(output_ptr.offset(7), charset[((input_chunk >> 16) & 0x3F) as usize]);
+                ptr::write(output_ptr, encode_table[((input_chunk >> 58) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(1), encode_table[((input_chunk >> 52) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(2), encode_table[((input_chunk >> 46) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(3), encode_table[((input_chunk >> 40) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(4), encode_table[((input_chunk >> 34) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(5), encode_table[((input_chunk >> 28) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(6), encode_table[((input_chunk >> 22) & 0x3F) as usize]);
+                ptr::write(output_ptr.offset(7), encode_table[((input_chunk >> 16) & 0x3F) as usize]);
                 output_ptr = output_ptr.offset(8);
             }
 
-            input_index += input_chunk_len;
-            fast_loop_output_buf_len += 8;
+            input_index += fast_chunk_len;
         }
     }
 
-    unsafe {
-        // expand len to include the bytes we just wrote
-        raw.set_len(fast_loop_output_buf_len);
-    }
+    // Encode the 0 to 7 bytes left after the fast loop.
 
-    // encode the 0 to 7 bytes left after the fast loop
-
-    let rem = input_bytes.len() % 3;
-    let start_of_rem = input_bytes.len() - rem;
+    let rem = input.len() % 3;
+    let start_of_rem = input.len() - rem;
+    let slow_chunk_len = 3;
 
     // start at the first index not handled by fast loop, which may be 0.
-    let mut leftover_index = input_index;
 
-    while leftover_index < start_of_rem {
-        raw.push(charset[(input_bytes[leftover_index] >> 2) as usize]);
-        raw.push(charset[((input_bytes[leftover_index] << 4 | input_bytes[leftover_index + 1] >> 4) & 0x3f) as usize]);
-        raw.push(charset[((input_bytes[leftover_index + 1] << 2 | input_bytes[leftover_index + 2] >> 6) & 0x3f) as usize]);
-        raw.push(charset[(input_bytes[leftover_index + 2] & 0x3f) as usize]);
-
-        leftover_index += 3;
+    while input_index < start_of_rem {
+        unsafe {
+            ptr::write(output_ptr,
+                       encode_table[(input[input_index] >> 2) as usize]);
+            ptr::write(output_ptr.offset(1),
+                       encode_table[((input[input_index] << 4 | input[input_index + 1] >> 4) & 0x3f) as usize]);
+            ptr::write(output_ptr.offset(2),
+                       encode_table[((input[input_index + 1] << 2 | input[input_index + 2] >> 6) & 0x3f) as usize]);
+            ptr::write(output_ptr.offset(3),
+                       encode_table[(input[input_index + 2] & 0x3f) as usize]);
+            output_ptr = output_ptr.offset(4);
+        }
+        input_index += slow_chunk_len;
     }
 
     if rem == 2 {
-        raw.push(charset[(input_bytes[start_of_rem] >> 2) as usize]);
-        raw.push(charset[((input_bytes[start_of_rem] << 4 | input_bytes[start_of_rem + 1] >> 4) & 0x3f) as usize]);
-        raw.push(charset[(input_bytes[start_of_rem + 1] << 2 & 0x3f) as usize]);
+        unsafe {
+            ptr::write(output_ptr,
+                       encode_table[(input[start_of_rem] >> 2) as usize]);
+            ptr::write(output_ptr.offset(1),
+                       encode_table[((input[start_of_rem] << 4 | input[start_of_rem + 1] >> 4) & 0x3f) as usize]);
+            ptr::write(output_ptr.offset(2),
+                       encode_table[(input[start_of_rem + 1] << 2 & 0x3f) as usize]);
+            output_ptr = output_ptr.offset(3);
+        }
     } else if rem == 1 {
-        raw.push(charset[(input_bytes[start_of_rem] >> 2) as usize]);
-        raw.push(charset[(input_bytes[start_of_rem] << 4 & 0x3f) as usize]);
-    }
-
-    if config.pad {
-        for _ in 0..((3 - rem) % 3) {
-            raw.push(0x3d);
+        unsafe {
+            ptr::write(output_ptr,
+                       encode_table[(input[start_of_rem] >> 2) as usize]);
+            ptr::write(output_ptr.offset(1),
+                       encode_table[(input[start_of_rem] << 4 & 0x3f) as usize]);
+            output_ptr = output_ptr.offset(2);
         }
     }
 
-    //TODO FIXME this does the wrong thing for nonempty buffers
-    if orig_buf_len == 0 {
-        if let LineWrap::Wrap(line_size, line_end) = config.line_wrap {
-            let len = raw.len();
-            let mut i = 0;
-            let mut j = 0;
+    // will not underflow: output_ptr is always at least as big as the starting output ptr
+    (output_ptr as usize) - (output.as_ptr() as usize)
+}
 
-            while i < len {
-                if i > 0 && i % line_size == 0 {
-                    match line_end {
-                        LineEnding::LF => { raw.insert(j, b'\n'); j += 1; }
-                        LineEnding::CRLF => { raw.insert(j, b'\r'); raw.insert(j + 1, b'\n'); j += 2; }
-                    }
-                }
-
-                i += 1;
-                j += 1;
-            }
-        }
+/// Write padding characters.
+/// `output` is the slice where padding should be written, of length at least 2.
+fn add_padding(input_len: usize, output: &mut[u8]) -> usize {
+    let rem = input_len % 3;
+    let mut bytes_written = 0;
+    for _ in 0..((3 - rem) % 3) {
+        output[bytes_written] = 0x3d;
+        bytes_written += 1;
     }
+
+    bytes_written
 }
 
 ///Decode from string reference as octets.
@@ -375,10 +450,7 @@ pub fn decode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T,
         input.as_ref()
     };
 
-    let ref decode_table = match config.char_set {
-        CharacterSet::Standard => tables::STANDARD_DECODE,
-        CharacterSet::UrlSafe => tables::URL_SAFE_DECODE,
-    };
+    let ref decode_table = config.char_set.decode_table();
 
     buffer.reserve(input_bytes.len() * 3 / 4);
 
@@ -574,88 +646,4 @@ pub fn decode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T,
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn encoded_size_correct() {
-        assert_eq!(0, encoded_size(0, STANDARD));
-
-        assert_eq!(4, encoded_size(1, STANDARD));
-        assert_eq!(4, encoded_size(2, STANDARD));
-        assert_eq!(4, encoded_size(3, STANDARD));
-
-        assert_eq!(8, encoded_size(4, STANDARD));
-        assert_eq!(8, encoded_size(5, STANDARD));
-        assert_eq!(8, encoded_size(6, STANDARD));
-
-        assert_eq!(12, encoded_size(7, STANDARD));
-        assert_eq!(12, encoded_size(8, STANDARD));
-        assert_eq!(12, encoded_size(9, STANDARD));
-
-        assert_eq!(72, encoded_size(54, STANDARD));
-
-        assert_eq!(76, encoded_size(55, STANDARD));
-        assert_eq!(76, encoded_size(56, STANDARD));
-        assert_eq!(76, encoded_size(57, STANDARD));
-
-        assert_eq!(80, encoded_size(58, STANDARD));
-    }
-
-    #[test]
-    fn encoded_size_correct_mime() {
-        assert_eq!(0, encoded_size(0, MIME));
-
-        assert_eq!(4, encoded_size(1, MIME));
-        assert_eq!(4, encoded_size(2, MIME));
-        assert_eq!(4, encoded_size(3, MIME));
-
-        assert_eq!(8, encoded_size(4, MIME));
-        assert_eq!(8, encoded_size(5, MIME));
-        assert_eq!(8, encoded_size(6, MIME));
-
-        assert_eq!(12, encoded_size(7, MIME));
-        assert_eq!(12, encoded_size(8, MIME));
-        assert_eq!(12, encoded_size(9, MIME));
-
-        assert_eq!(72, encoded_size(54, MIME));
-
-        assert_eq!(78, encoded_size(55, MIME));
-        assert_eq!(78, encoded_size(56, MIME));
-        assert_eq!(78, encoded_size(57, MIME));
-
-        assert_eq!(82, encoded_size(58, MIME));
-    }
-
-    #[test]
-    fn encoded_size_correct_lf() {
-        let config = Config::new(
-            CharacterSet::Standard,
-            true,
-            false,
-            LineWrap::Wrap(76, LineEnding::LF)
-        );
-
-        assert_eq!(0, encoded_size(0, config));
-
-        assert_eq!(4, encoded_size(1, config));
-        assert_eq!(4, encoded_size(2, config));
-        assert_eq!(4, encoded_size(3, config));
-
-        assert_eq!(8, encoded_size(4, config));
-        assert_eq!(8, encoded_size(5, config));
-        assert_eq!(8, encoded_size(6, config));
-
-        assert_eq!(12, encoded_size(7, config));
-        assert_eq!(12, encoded_size(8, config));
-        assert_eq!(12, encoded_size(9, config));
-
-        assert_eq!(72, encoded_size(54, config));
-
-        assert_eq!(77, encoded_size(55, config));
-        assert_eq!(77, encoded_size(56, config));
-        assert_eq!(77, encoded_size(57, config));
-
-        assert_eq!(81, encoded_size(58, config));
-    }
-}
+mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,19 +302,19 @@ pub fn encode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config, buf
 fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> usize {
     let mut input_index: usize = 0;
 
-    let blocks_per_fast_loop = 4;
+    const BLOCKS_PER_FAST_LOOP: usize = 4;
 
     // we read 8 bytes at a time (u64) but only actually consume 6 of those bytes. Thus, we need
     // 2 trailing bytes to be available to read..
-    let last_fast_index = input.len().saturating_sub(blocks_per_fast_loop * 6 + 2);
+    let last_fast_index = input.len().saturating_sub(BLOCKS_PER_FAST_LOOP * 6 + 2);
     let mut output_index = 0;
 
     if last_fast_index > 0 {
         while input_index <= last_fast_index {
             // Major performance wins from letting the optimizer do the bounds check once, mostly
             // on the output side
-            let input_chunk = &input[input_index..(input_index + (blocks_per_fast_loop * 6 + 2))];
-            let mut output_chunk = &mut output[output_index..(output_index + blocks_per_fast_loop * 8)];
+            let input_chunk = &input[input_index..(input_index + (BLOCKS_PER_FAST_LOOP * 6 + 2))];
+            let mut output_chunk = &mut output[output_index..(output_index + BLOCKS_PER_FAST_LOOP * 8)];
 
             // Hand-unrolling for 32 vs 16 or 8 bytes produces yields performance about equivalent
             // to unsafe pointer code on a Xeon E5-1650v3. 64 byte unrolling was slightly better for
@@ -368,8 +368,8 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
             output_chunk[30] = encode_table[((input_u64 >> 22) & 0x3F) as usize];
             output_chunk[31] = encode_table[((input_u64 >> 16) & 0x3F) as usize];
 
-            output_index += blocks_per_fast_loop * 8;
-            input_index += blocks_per_fast_loop * 6;
+            output_index += BLOCKS_PER_FAST_LOOP * 8;
+            input_index += BLOCKS_PER_FAST_LOOP * 6;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,16 @@ pub enum CharacterSet {
 
 impl CharacterSet {
     fn encode_table(&self) -> &'static [u8; 64] {
-        match self {
-            &CharacterSet::Standard => tables::STANDARD_ENCODE,
-            &CharacterSet::UrlSafe => tables::URL_SAFE_ENCODE
+        match *self {
+            CharacterSet::Standard => tables::STANDARD_ENCODE,
+            CharacterSet::UrlSafe => tables::URL_SAFE_ENCODE
         }
     }
 
     fn decode_table(&self) -> &'static [u8; 256] {
-        match self {
-            &CharacterSet::Standard => tables::STANDARD_DECODE,
-            &CharacterSet::UrlSafe => tables::URL_SAFE_DECODE
+        match *self {
+            CharacterSet::Standard => tables::STANDARD_DECODE,
+            CharacterSet::UrlSafe => tables::URL_SAFE_DECODE
         }
     }
 }
@@ -311,6 +311,7 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
     let mut input_index: usize = 0;
 
     const BLOCKS_PER_FAST_LOOP: usize = 4;
+    const LOW_SIX_BITS: u64 = 0x3F;
 
     // we read 8 bytes at a time (u64) but only actually consume 6 of those bytes. Thus, we need
     // 2 trailing bytes to be available to read..
@@ -334,47 +335,47 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
 
             let input_u64 = BigEndian::read_u64(&input_chunk[0..]);
 
-            output_chunk[0] = encode_table[((input_u64 >> 58) & 0x3F) as usize];
-            output_chunk[1] = encode_table[((input_u64 >> 52) & 0x3F) as usize];
-            output_chunk[2] = encode_table[((input_u64 >> 46) & 0x3F) as usize];
-            output_chunk[3] = encode_table[((input_u64 >> 40) & 0x3F) as usize];
-            output_chunk[4] = encode_table[((input_u64 >> 34) & 0x3F) as usize];
-            output_chunk[5] = encode_table[((input_u64 >> 28) & 0x3F) as usize];
-            output_chunk[6] = encode_table[((input_u64 >> 22) & 0x3F) as usize];
-            output_chunk[7] = encode_table[((input_u64 >> 16) & 0x3F) as usize];
+            output_chunk[0] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[1] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[2] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[3] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[4] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[5] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[6] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[7] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
             let input_u64 = BigEndian::read_u64(&input_chunk[6..]);
 
-            output_chunk[8] = encode_table[((input_u64 >> 58) & 0x3F) as usize];
-            output_chunk[9] = encode_table[((input_u64 >> 52) & 0x3F) as usize];
-            output_chunk[10] = encode_table[((input_u64 >> 46) & 0x3F) as usize];
-            output_chunk[11] = encode_table[((input_u64 >> 40) & 0x3F) as usize];
-            output_chunk[12] = encode_table[((input_u64 >> 34) & 0x3F) as usize];
-            output_chunk[13] = encode_table[((input_u64 >> 28) & 0x3F) as usize];
-            output_chunk[14] = encode_table[((input_u64 >> 22) & 0x3F) as usize];
-            output_chunk[15] = encode_table[((input_u64 >> 16) & 0x3F) as usize];
+            output_chunk[8] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[9] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[10] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[11] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[12] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[13] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[14] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[15] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
             let input_u64 = BigEndian::read_u64(&input_chunk[12..]);
 
-            output_chunk[16] = encode_table[((input_u64 >> 58) & 0x3F) as usize];
-            output_chunk[17] = encode_table[((input_u64 >> 52) & 0x3F) as usize];
-            output_chunk[18] = encode_table[((input_u64 >> 46) & 0x3F) as usize];
-            output_chunk[19] = encode_table[((input_u64 >> 40) & 0x3F) as usize];
-            output_chunk[20] = encode_table[((input_u64 >> 34) & 0x3F) as usize];
-            output_chunk[21] = encode_table[((input_u64 >> 28) & 0x3F) as usize];
-            output_chunk[22] = encode_table[((input_u64 >> 22) & 0x3F) as usize];
-            output_chunk[23] = encode_table[((input_u64 >> 16) & 0x3F) as usize];
+            output_chunk[16] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[17] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[18] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[19] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[20] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[21] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[22] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[23] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
             let input_u64 = BigEndian::read_u64(&input_chunk[18..]);
 
-            output_chunk[24] = encode_table[((input_u64 >> 58) & 0x3F) as usize];
-            output_chunk[25] = encode_table[((input_u64 >> 52) & 0x3F) as usize];
-            output_chunk[26] = encode_table[((input_u64 >> 46) & 0x3F) as usize];
-            output_chunk[27] = encode_table[((input_u64 >> 40) & 0x3F) as usize];
-            output_chunk[28] = encode_table[((input_u64 >> 34) & 0x3F) as usize];
-            output_chunk[29] = encode_table[((input_u64 >> 28) & 0x3F) as usize];
-            output_chunk[30] = encode_table[((input_u64 >> 22) & 0x3F) as usize];
-            output_chunk[31] = encode_table[((input_u64 >> 16) & 0x3F) as usize];
+            output_chunk[24] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[25] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[26] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[27] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[28] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[29] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[30] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[31] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
             output_index += BLOCKS_PER_FAST_LOOP * 8;
             input_index += BLOCKS_PER_FAST_LOOP * 6;
@@ -382,6 +383,8 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
     }
 
     // Encode what's left after the fast loop.
+
+    const LOW_SIX_BITS_U8: u8 = 0x3F;
 
     let rem = input.len() % 3;
     let start_of_rem = input.len() - rem;
@@ -393,9 +396,9 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
         let mut output_chunk = &mut output[output_index..(output_index + 4)];
 
         output_chunk[0] = encode_table[(input_chunk[0] >> 2) as usize];
-        output_chunk[1] = encode_table[((input_chunk[0] << 4 | input_chunk[1] >> 4) & 0x3f) as usize];
-        output_chunk[2] = encode_table[((input_chunk[1] << 2 | input_chunk[2] >> 6) & 0x3f) as usize];
-        output_chunk[3] = encode_table[(input_chunk[2] & 0x3f) as usize];
+        output_chunk[1] = encode_table[((input_chunk[0] << 4 | input_chunk[1] >> 4) & LOW_SIX_BITS_U8) as usize];
+        output_chunk[2] = encode_table[((input_chunk[1] << 2 | input_chunk[2] >> 6) & LOW_SIX_BITS_U8) as usize];
+        output_chunk[3] = encode_table[(input_chunk[2] & LOW_SIX_BITS_U8) as usize];
 
         input_index += 3;
         output_index += 4;
@@ -403,12 +406,12 @@ fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64]) -> 
 
     if rem == 2 {
         output[output_index] = encode_table[(input[start_of_rem] >> 2) as usize];
-        output[output_index + 1] = encode_table[((input[start_of_rem] << 4 | input[start_of_rem + 1] >> 4) & 0x3f) as usize];
-        output[output_index + 2] = encode_table[(input[start_of_rem + 1] << 2 & 0x3f) as usize];
+        output[output_index + 1] = encode_table[((input[start_of_rem] << 4 | input[start_of_rem + 1] >> 4) & LOW_SIX_BITS_U8) as usize];
+        output[output_index + 2] = encode_table[((input[start_of_rem + 1] << 2) & LOW_SIX_BITS_U8) as usize];
         output_index += 3;
     } else if rem == 1 {
         output[output_index] = encode_table[(input[start_of_rem] >> 2) as usize];
-        output[output_index + 1] = encode_table[(input[start_of_rem] << 4 & 0x3f) as usize];
+        output[output_index + 1] = encode_table[((input[start_of_rem] << 4) & LOW_SIX_BITS_U8) as usize];
         output_index += 2;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,21 +278,29 @@ pub fn encode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config, buf
                          .expect("usize overflow when calculating expanded buffer size"), 0);
 
     let mut b64_output = &mut buf_bytes[orig_buf_len..];
-    let b64_bytes_written = encode_to_slice(input_bytes, b64_output,
-                                                config.char_set.encode_table());
 
-    let padding_bytes = if config.pad {
-        add_padding(input_bytes.len(), &mut b64_output[b64_bytes_written..])
+    let encoded_bytes = encode_with_padding(input_bytes, b64_output, config.char_set.encode_table(),
+                                            config.pad);
+
+    if let LineWrap::Wrap(line_len, line_end) = config.line_wrap {
+        line_wrap(b64_output, encoded_bytes, line_len, line_end);
+    }
+}
+
+/// Encode input bytes and pad if configured.
+/// `output` must be long enough to hold the encoded `input` with padding.
+/// Returns the number of bytes written.
+fn encode_with_padding(input: &[u8], output: &mut [u8], encode_table: &[u8; 64], pad: bool) -> usize {
+    let b64_bytes_written = encode_to_slice(input, output, encode_table);
+
+    let padding_bytes = if pad {
+        add_padding(input.len(), &mut output[b64_bytes_written..])
     } else {
         0
     };
 
-    let wrappable_bytes = b64_bytes_written.checked_add(padding_bytes)
-        .expect("usize overflow when calculating b64 length");
-
-    if let LineWrap::Wrap(line_len, line_end) = config.line_wrap {
-        line_wrap(b64_output, wrappable_bytes, line_len, line_end);
-    }
+    b64_bytes_written.checked_add(padding_bytes)
+        .expect("usize overflow when calculating b64 length")
 }
 
 /// Encode input bytes to utf8 base64 bytes. Does not pad or line wrap.
@@ -413,7 +421,7 @@ fn add_padding(input_len: usize, output: &mut[u8]) -> usize {
     let rem = input_len % 3;
     let mut bytes_written = 0;
     for _ in 0..((3 - rem) % 3) {
-        output[bytes_written] = 0x3d;
+        output[bytes_written] = b'=';
         bytes_written += 1;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,9 @@ pub enum LineEnding {
 
 impl LineEnding {
     fn len(&self) -> usize {
-        match self {
-            &LineEnding::LF => 1,
-            &LineEnding::CRLF => 2
+        match *self {
+            LineEnding::LF => 1,
+            LineEnding::CRLF => 2
         }
     }
 }
@@ -487,7 +487,7 @@ pub fn decode_config_buf<T: ?Sized + AsRef<[u8]>>(input: &T,
         input.as_ref()
     };
 
-    let ref decode_table = config.char_set.decode_table();
+    let decode_table = &config.char_set.decode_table();
 
     buffer.reserve(input_bytes.len() * 3 / 4);
 

--- a/src/line_wrap.rs
+++ b/src/line_wrap.rs
@@ -84,8 +84,12 @@ pub fn line_wrap_parameters(input_len: usize, line_len: usize, line_ending: Line
 pub fn line_wrap(encoded_buf: &mut [u8], input_len: usize, line_len: usize, line_ending: LineEnding) -> usize {
     let line_wrap_params = line_wrap_parameters(input_len, line_len, line_ending);
 
+    // ptr.offset() is undefined if it wraps, and there is no checked_offset(). However, because
+    // we perform this check up front to make sure we have enough capacity, we know that none of
+    // the subsequent pointer operations (assuming they implement the desired behavior of course!)
+    // will overflow.
     assert!(encoded_buf.len() >= line_wrap_params.total_len,
-    "Buffer must be able to hold encoded data after line wrapping");
+        "Buffer must be able to hold encoded data after line wrapping");
 
     // Move the last line, either partial or full, by itself as it does not have a line ending
     // afterwards

--- a/src/line_wrap.rs
+++ b/src/line_wrap.rs
@@ -1,0 +1,339 @@
+extern crate num;
+
+use super::*;
+
+use std::{str, ptr};
+
+use self::num::ToPrimitive;
+
+#[derive(Debug, PartialEq)]
+pub struct LineWrapParameters {
+    // number of lines that need an ending
+    pub lines_with_endings: usize,
+    // length of last line (which never needs an ending)
+    pub last_line_len: usize,
+    // length of lines that need an ending (which are always full lines), with their endings
+    pub total_full_wrapped_lines_len: usize,
+    // length of all lines, including endings for the ones that need them
+    pub total_len: usize,
+    // length of the line endings only
+    pub total_line_endings_len: usize
+}
+
+/// Calculations about how many lines we'll get for a given line length, line ending, etc.
+/// This assumes that the last line will not get an ending, even if it is the full line length.
+pub fn line_wrap_parameters(input_len: usize, line_len: usize, line_ending: LineEnding)
+                            -> LineWrapParameters {
+    let line_ending_len = line_ending.len();
+
+    if input_len <= line_len {
+        // no wrapping needed
+        return LineWrapParameters {
+            lines_with_endings: 0,
+            last_line_len: input_len,
+            total_full_wrapped_lines_len: 0,
+            total_len: input_len,
+            total_line_endings_len: 0
+        };
+    };
+
+    // num_lines_with_endings > 0, last_line_length > 0
+    let (num_lines_with_endings, last_line_length) = if input_len % line_len > 0 {
+        // Every full line has an ending since there is a partial line at the end
+        (input_len / line_len, input_len % line_len)
+    } else {
+        // Every line is a full line, but no trailing ending.
+        // Subtraction will not underflow since we know input_len > line_len.
+        (input_len / line_len - 1, line_len)
+    };
+
+    // TODO should we expose exceeding usize via Result to be kind to 16-bit users? Or is that
+    // always going to be a panic anyway in practice? If we choose to use a Result we could pull
+    // line wrapping out of the normal encode path and have it be a separate step. Then only users
+    // who need line wrapping would care about the possibility for error.
+
+    let single_full_line_with_ending_len = line_len.checked_add(line_ending_len)
+        .expect("Line length with ending exceeds usize");
+    // length of just the full lines with line endings
+    let total_full_wrapped_lines_len = num_lines_with_endings
+        .checked_mul(single_full_line_with_ending_len)
+        .expect("Full lines with endings length exceeds usize");
+    // all lines with appropriate endings, including the last line
+    let total_all_wrapped_len = total_full_wrapped_lines_len.checked_add(last_line_length)
+        .expect("All lines with endings length exceeds usize");
+    let total_line_endings_len = num_lines_with_endings.checked_mul(line_ending_len)
+        .expect("Total line endings length exceeds usize");
+
+    LineWrapParameters {
+        lines_with_endings: num_lines_with_endings,
+        last_line_len: last_line_length,
+        total_full_wrapped_lines_len: total_full_wrapped_lines_len,
+        total_len: total_all_wrapped_len,
+        total_line_endings_len: total_line_endings_len
+    }
+}
+
+
+/// Insert line endings into the encoded base64 after each complete line (except the last line, even
+/// if it is complete).
+/// The provided buffer must be large enough to handle the increased size after endings are
+/// inserted.
+/// `input_len` is the length of the encoded data in `encoded_buf`.
+/// `line_len` is the width without line ending characters.
+/// Returns the number of line ending bytes added.
+pub fn line_wrap(encoded_buf: &mut [u8], input_len: usize, line_len: usize, line_ending: LineEnding) -> usize {
+    let line_wrap_params = line_wrap_parameters(input_len, line_len, line_ending);
+
+    assert!(encoded_buf.len() >= line_wrap_params.total_len,
+    "Buffer must be able to hold encoded data after line wrapping");
+
+    // Move the last line, either partial or full, by itself as it does not have a line ending
+    // afterwards
+    unsafe {
+        let last_line_start = line_wrap_params.lines_with_endings.checked_mul(line_len)
+            .and_then(|o| o.to_isize())
+            .map(|o| encoded_buf.as_ptr().offset(o))
+            .expect("Start of last line in input exceeds isize");
+        // last line starts immediately after all the wrapped full lines
+        let new_line_start = line_wrap_params.total_full_wrapped_lines_len.to_isize()
+            .map(|o| encoded_buf.as_mut_ptr().offset(o))
+            .expect("Full lines with endings length exceeds usize");
+
+        ptr::copy(last_line_start, new_line_start, line_wrap_params.last_line_len);
+    }
+
+    let mut line_ending_bytes = 0;
+
+    let line_len_isize = line_len.to_isize().expect("line_len must fit in isize");
+    let line_ending_len = line_ending.len();
+
+    // handle the full lines
+    for line_num in 0..line_wrap_params.lines_with_endings {
+        // doesn't underflow because line_num < lines_with_endings
+        let lines_before_this_line = line_wrap_params.lines_with_endings - 1 - line_num;
+        let line_start_offset = lines_before_this_line.checked_mul(line_len)
+            .and_then(|l| l.to_isize())
+            .expect("Line start offset exceeds isize");
+        let total_endings_to_insert_before_this_line =
+            lines_before_this_line.checked_mul(line_ending_len)
+                .and_then(|t| t.to_isize())
+                .expect("Cumulative line ending length before this line exceeds isize");
+
+        unsafe {
+            let orig_line_start = encoded_buf.as_ptr().offset(line_start_offset);
+
+            let new_line_start = encoded_buf.as_mut_ptr().offset(line_start_offset)
+                .offset(total_endings_to_insert_before_this_line);
+
+            ptr::copy(orig_line_start, new_line_start, line_len);
+            match line_ending {
+                LineEnding::LF => {
+                    ptr::write(new_line_start.offset(line_len_isize), b'\n');
+                    line_ending_bytes += 1;
+                }
+                LineEnding::CRLF => {
+                    ptr::write(new_line_start.offset(line_len_isize), b'\r');
+                    ptr::write(new_line_start.offset(line_len_isize).offset(1), b'\n');
+                    line_ending_bytes += 2;
+                }
+            }
+        }
+    }
+
+    assert_eq!(line_wrap_params.total_line_endings_len, line_ending_bytes);
+
+    line_ending_bytes
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate rand;
+
+    use super::super::*;
+    use super::*;
+
+    use self::rand::Rng;
+    use self::rand::distributions::{IndependentSample, Range};
+
+    #[test]
+    fn line_params_perfect_multiple_of_line_length_lf() {
+        let params = line_wrap_parameters(100, 20, LineEnding::LF);
+
+        assert_eq!(LineWrapParameters {
+            lines_with_endings: 4,
+            last_line_len: 20,
+            total_full_wrapped_lines_len: 84,
+            total_len: 104,
+            total_line_endings_len: 4
+        }, params);
+    }
+
+    #[test]
+    fn line_params_partial_last_line_crlf() {
+        let params = line_wrap_parameters(103, 20, LineEnding::CRLF);
+
+        assert_eq!(LineWrapParameters {
+            lines_with_endings: 5,
+            last_line_len: 3,
+            total_full_wrapped_lines_len: 110,
+            total_len: 113,
+            total_line_endings_len: 10
+        }, params);
+    }
+
+    #[test]
+    fn line_params_line_len_1_crlf() {
+        let params = line_wrap_parameters(100, 1, LineEnding::CRLF);
+
+        assert_eq!(LineWrapParameters {
+            lines_with_endings: 99,
+            last_line_len: 1,
+            total_full_wrapped_lines_len: 99 * 3,
+            total_len: 99 * 3 + 1,
+            total_line_endings_len: 99 * 2
+        }, params);
+    }
+
+    #[test]
+    fn line_params_line_len_longer_than_input_crlf() {
+        let params = line_wrap_parameters(100, 200, LineEnding::CRLF);
+
+        assert_eq!(LineWrapParameters {
+            lines_with_endings: 0,
+            last_line_len: 100,
+            total_full_wrapped_lines_len: 0,
+            total_len: 100,
+            total_line_endings_len: 0
+        }, params);
+    }
+
+    #[test]
+    fn line_params_line_len_same_as_input_crlf() {
+        let params = line_wrap_parameters(100, 100, LineEnding::CRLF);
+
+        assert_eq!(LineWrapParameters {
+            lines_with_endings: 0,
+            last_line_len: 100,
+            total_full_wrapped_lines_len: 0,
+            total_len: 100,
+            total_line_endings_len: 0
+        }, params);
+    }
+
+    #[test]
+    fn line_wrap_length_1_lf() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4];
+
+        do_line_wrap(&mut buf, 1, LineEnding::LF);
+
+        assert_eq!(vec![0x1, 0xA, 0x2, 0xA, 0x3, 0xA, 0x4], buf);
+    }
+
+    #[test]
+    fn line_wrap_length_1_crlf() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4];
+
+        do_line_wrap(&mut buf, 1, LineEnding::CRLF);
+
+        assert_eq!(vec![0x1, 0xD, 0xA, 0x2, 0xD, 0xA, 0x3, 0xD, 0xA, 0x4], buf);
+    }
+
+    #[test]
+    fn line_wrap_length_2_lf_full_lines() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4];
+
+        do_line_wrap(&mut buf, 2, LineEnding::LF);
+
+        assert_eq!(vec![0x1, 0x2, 0xA, 0x3, 0x4], buf);
+    }
+
+    #[test]
+    fn line_wrap_length_2_crlf_full_lines() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4];
+
+        do_line_wrap(&mut buf, 2, LineEnding::CRLF);
+
+        assert_eq!(vec![0x1, 0x2, 0xD, 0xA, 0x3, 0x4], buf);
+    }
+
+    #[test]
+    fn line_wrap_length_2_lf_partial_line() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4, 0x5];
+
+        do_line_wrap(&mut buf, 2, LineEnding::LF);
+
+        assert_eq!(vec![0x1, 0x2, 0xA, 0x3, 0x4, 0xA, 0x5], buf);
+    }
+
+    #[test]
+    fn line_wrap_length_2_crlf_partial_line() {
+        let mut buf = vec![0x1, 0x2, 0x3, 0x4, 0x5];
+
+        do_line_wrap(&mut buf, 2, LineEnding::CRLF);
+
+        assert_eq!(vec![0x1, 0x2, 0xD, 0xA, 0x3, 0x4, 0xD, 0xA, 0x5], buf);
+    }
+
+    #[test]
+    fn line_wrap_random() {
+        let mut buf: Vec<u8> = Vec::new();
+        let buf_range = Range::new(10, 1000);
+        let line_range = Range::new(10, 100);
+        let mut rng = rand::weak_rng();
+
+        for _ in 0..10_000 {
+            buf.clear();
+
+            let buf_len = buf_range.ind_sample(&mut rng);
+            let line_len = line_range.ind_sample(&mut rng);
+            let line_ending = if rng.gen() {
+                LineEnding::LF
+            } else {
+                LineEnding::CRLF
+            };
+            let line_ending_len = line_ending.len();
+
+            for _ in 0..buf_len {
+                buf.push(rng.gen());
+            }
+
+            let line_wrap_params = line_wrap_parameters(buf_len, line_len, line_ending);
+
+            let not_wrapped_buf = buf.to_vec();
+
+            let line_ending_bytes = do_line_wrap(&mut buf, line_len, line_ending);
+
+            assert_eq!(buf_len + line_wrap_params.lines_with_endings * line_ending_len, buf.len());
+            assert_eq!(line_wrap_params.total_len, buf.len());
+            assert_eq!(line_wrap_params.total_line_endings_len, line_ending_bytes);
+
+            // remove the endings
+            for line_ending_num in 0..line_wrap_params.lines_with_endings {
+                let line_ending_offset = (line_ending_num + 1) * line_len;
+
+                for _ in 0..line_ending_len {
+                    buf.remove(line_ending_offset);
+                }
+            }
+
+            assert_eq!(not_wrapped_buf, buf);
+        }
+    }
+
+    fn do_line_wrap(buf: &mut Vec<u8>, line_len: usize, line_ending: LineEnding) -> usize {
+        // a 3x inflation is enough for the worst case: line length 1, crlf ending
+        let orig_len = buf.len();
+        buf.reserve(orig_len * 2);
+        unsafe {
+            buf.set_len(orig_len * 3);
+        }
+
+        let bytes_written = line_wrap(&mut buf[..], orig_len, line_len, line_ending);
+
+        unsafe {
+            buf.set_len(orig_len + bytes_written);
+        }
+
+        bytes_written
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,337 @@
+extern crate rand;
+
+use super::*;
+use super::line_wrap::{line_wrap_parameters};
+use self::rand::Rng;
+use self::rand::distributions::{IndependentSample, Range};
+
+#[test]
+fn encoded_size_correct_standard() {
+    assert_encoded_length(0, 0, STANDARD);
+
+    assert_encoded_length(1, 4, STANDARD);
+    assert_encoded_length(2, 4, STANDARD);
+    assert_encoded_length(3, 4, STANDARD);
+
+    assert_encoded_length(4, 8, STANDARD);
+    assert_encoded_length(5, 8, STANDARD);
+    assert_encoded_length(6, 8, STANDARD);
+
+    assert_encoded_length(7, 12, STANDARD);
+    assert_encoded_length(8, 12, STANDARD);
+    assert_encoded_length(9, 12, STANDARD);
+
+    assert_encoded_length(54, 72, STANDARD);
+
+    assert_encoded_length(55, 76, STANDARD);
+    assert_encoded_length(56, 76, STANDARD);
+    assert_encoded_length(57, 76, STANDARD);
+
+    assert_encoded_length(58, 80, STANDARD);
+}
+
+#[test]
+fn encoded_size_correct_no_pad_no_wrap() {
+    assert_encoded_length(0, 0, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(1, 2, URL_SAFE_NO_PAD);
+    assert_encoded_length(2, 3, URL_SAFE_NO_PAD);
+    assert_encoded_length(3, 4, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(4, 6, URL_SAFE_NO_PAD);
+    assert_encoded_length(5, 7, URL_SAFE_NO_PAD);
+    assert_encoded_length(6, 8, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(7, 10, URL_SAFE_NO_PAD);
+    assert_encoded_length(8, 11, URL_SAFE_NO_PAD);
+    assert_encoded_length(9, 12, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(54, 72, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(55, 74, URL_SAFE_NO_PAD);
+    assert_encoded_length(56, 75, URL_SAFE_NO_PAD);
+    assert_encoded_length(57, 76, URL_SAFE_NO_PAD);
+
+    assert_encoded_length(58, 78, URL_SAFE_NO_PAD);
+}
+
+#[test]
+fn encoded_size_correct_mime() {
+    assert_encoded_length(0, 0, MIME);
+
+    assert_encoded_length(1, 4, MIME);
+    assert_encoded_length(2, 4, MIME);
+    assert_encoded_length(3, 4, MIME);
+
+    assert_encoded_length(4, 8, MIME);
+    assert_encoded_length(5, 8, MIME);
+    assert_encoded_length(6, 8, MIME);
+
+    assert_encoded_length(7, 12, MIME);
+    assert_encoded_length(8, 12, MIME);
+    assert_encoded_length(9, 12, MIME);
+
+    assert_encoded_length(54, 72, MIME);
+
+    assert_encoded_length(55, 76, MIME);
+    assert_encoded_length(56, 76, MIME);
+    assert_encoded_length(57, 76, MIME);
+
+    assert_encoded_length(58, 82, MIME);
+    assert_encoded_length(59, 82, MIME);
+    assert_encoded_length(60, 82, MIME);
+}
+
+#[test]
+fn encoded_size_correct_lf_pad() {
+    let config = Config::new(
+        CharacterSet::Standard,
+        true,
+        false,
+        LineWrap::Wrap(76, LineEnding::LF)
+    );
+
+    assert_encoded_length(0, 0, config);
+
+    assert_encoded_length(1, 4, config);
+    assert_encoded_length(2, 4, config);
+    assert_encoded_length(3, 4, config);
+
+    assert_encoded_length(4, 8, config);
+    assert_encoded_length(5, 8, config);
+    assert_encoded_length(6, 8, config);
+
+    assert_encoded_length(7, 12, config);
+    assert_encoded_length(8, 12, config);
+    assert_encoded_length(9, 12, config);
+
+    assert_encoded_length(54, 72, config);
+
+    assert_encoded_length(55, 76, config);
+    assert_encoded_length(56, 76, config);
+    assert_encoded_length(57, 76, config);
+
+    // one fewer than MIME
+    assert_encoded_length(58, 81, config);
+    assert_encoded_length(59, 81, config);
+    assert_encoded_length(60, 81, config);
+}
+
+#[test]
+fn encode_random() {
+    let mut input_buf: Vec<u8> = Vec::new();
+    let mut encoded_buf = String::new();
+    let mut rng = rand::weak_rng();
+    let input_len_range = Range::new(10, 1000);
+    let line_len_range = Range::new(10, 100);
+
+    for _ in 0..10_000 {
+        input_buf.clear();
+        encoded_buf.clear();
+
+        let input_len = input_len_range.ind_sample(&mut rng);
+
+        let config = random_config(&mut rng, &line_len_range);
+
+        for _ in 0..input_len {
+            input_buf.push(rng.gen());
+        }
+
+        encode_config_buf(&input_buf, config, &mut encoded_buf);
+
+        assert_encode_sanity(&encoded_buf, &config, input_len);
+    }
+}
+
+
+#[test]
+fn encode_into_nonempty_buffer_doesnt_clobber_existing_contents() {
+    let mut orig_data = Vec::new();
+    let mut prefix = String::new();
+    let mut encoded_data_no_prefix = String::new();
+    let mut encoded_data_with_prefix = String::new();
+    let mut decoded = Vec::new();
+
+    let prefix_len_range = Range::new(10, 1000);
+    let input_len_range = Range::new(2, 1000);
+    let line_len_range = Range::new(10, 100);
+
+    let mut rng = rand::weak_rng();
+
+
+    for _ in 0..10_000 {
+        orig_data.clear();
+        prefix.clear();
+        encoded_data_no_prefix.clear();
+        encoded_data_with_prefix.clear();
+        decoded.clear();
+
+        let input_len = input_len_range.ind_sample(&mut rng);
+
+        for _ in 0..input_len {
+            orig_data.push(rng.gen());
+        }
+
+        let prefix_len = prefix_len_range.ind_sample(&mut rng);
+        for _ in 0..prefix_len {
+            // getting convenient random single-byte printable chars that aren't base64 is annoying
+            prefix.push('#');
+        }
+        encoded_data_with_prefix.push_str(&prefix);
+
+        let config = random_config(&mut rng, &line_len_range);
+        encode_config_buf(&orig_data, config, &mut encoded_data_no_prefix);
+        encode_config_buf(&orig_data, config, &mut encoded_data_with_prefix);
+
+        assert_eq!(encoded_data_no_prefix.len() + prefix_len, encoded_data_with_prefix.len());
+        assert_encode_sanity(&encoded_data_no_prefix, &config, input_len);
+        assert_encode_sanity(&encoded_data_with_prefix[prefix_len..], &config, input_len);
+
+        // append plain encode onto prefix
+        prefix.push_str(&mut encoded_data_no_prefix);
+
+        assert_eq!(prefix, encoded_data_with_prefix);
+
+        // since we know we have the correct count of line endings, it's reasonable to simply remove
+        // them without worrying about where they are
+        let encoded_no_line_endings: String = encoded_data_no_prefix.chars()
+            .filter(|&c| c != '\r' && c != '\n')
+            .collect();
+
+        decode_config_buf(&encoded_no_line_endings, config, &mut decoded).unwrap();
+        assert_eq!(orig_data, decoded);
+    }
+}
+
+#[test]
+fn decode_into_nonempty_buffer_doesnt_clobber_existing_contents() {
+    let mut orig_data = Vec::new();
+    let mut encoded_data = String::new();
+    let mut decoded_with_prefix = Vec::new();
+    let mut decoded_without_prefix = Vec::new();
+    let mut prefix = Vec::new();
+
+    let prefix_len_range = Range::new(10, 1000);
+    let input_len_range = Range::new(2, 1000);
+    let line_len_range = Range::new(10, 100);
+
+    let mut rng = rand::weak_rng();
+
+
+    for _ in 0..10_000 {
+        orig_data.clear();
+        encoded_data.clear();
+        decoded_with_prefix.clear();
+        decoded_without_prefix.clear();
+        prefix.clear();
+
+        let input_len = input_len_range.ind_sample(&mut rng);
+
+        for _ in 0..input_len {
+            orig_data.push(rng.gen());
+        }
+
+        let config = random_config(&mut rng, &line_len_range);
+        encode_config_buf(&orig_data, config, &mut encoded_data);
+        assert_encode_sanity(&encoded_data, &config, input_len);
+
+        let prefix_len = prefix_len_range.ind_sample(&mut rng);
+
+        // fill the buf with a prefix
+        for _ in 0..prefix_len {
+            prefix.push(rng.gen());
+        }
+
+        decoded_with_prefix.resize(prefix_len, 0);
+        decoded_with_prefix.copy_from_slice(&prefix);
+
+        // remove line wrapping
+        let encoded_no_line_endings: String = encoded_data.chars()
+            .filter(|&c| c != '\r' && c != '\n')
+            .collect();
+
+        // decode into the non-empty buf
+        decode_config_buf(&encoded_no_line_endings, config, &mut decoded_with_prefix).unwrap();
+        // also decode into the empty buf
+        decode_config_buf(&encoded_no_line_endings, config, &mut decoded_without_prefix).unwrap();
+
+        assert_eq!(prefix_len + decoded_without_prefix.len(), decoded_with_prefix.len());
+        assert_eq!(orig_data, decoded_without_prefix);
+
+        // append plain decode onto prefix
+        prefix.append(&mut decoded_without_prefix);
+
+        assert_eq!(prefix, decoded_with_prefix);
+    }
+}
+
+fn assert_encoded_length(input_len: usize, encoded_len: usize, config: Config) {
+    assert_eq!(encoded_len, encoded_size(input_len, &config));
+
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut rng = rand::weak_rng();
+
+    for _ in 0..input_len {
+        bytes.push(rng.gen());
+    }
+
+    let encoded = encode_config(&bytes, config);
+    assert_encode_sanity(&encoded, &config, input_len);
+
+    assert_eq!(encoded_len, encoded.len());
+}
+
+fn assert_encode_sanity(encoded: &str, config: &Config, input_len: usize) {
+    let input_rem = input_len % 3;
+    let (expected_padding_len, last_encoded_chunk_len) = if input_rem > 0 {
+        if config.pad {
+            (3 - input_rem, 4)
+        } else {
+            (0, input_rem + 1)
+        }
+    } else {
+        (0, 0)
+    };
+
+    let b64_only_len = (input_len / 3) * 4 + last_encoded_chunk_len;
+
+    let expected_line_ending_len = match config.line_wrap {
+        LineWrap::NoWrap => 0,
+        LineWrap::Wrap(line_len, line_ending) =>
+            line_wrap_parameters(b64_only_len, line_len, line_ending).total_line_endings_len
+    };
+
+    let expected_encoded_len = encoded_size(input_len, &config);
+
+    assert_eq!(expected_encoded_len, encoded.len());
+
+    let line_endings_len = encoded.chars().filter(|&c| c == '\r' || c == '\n').count();
+    let padding_len = encoded.chars().filter(|&c| c == '=').count();
+
+    assert_eq!(expected_padding_len, padding_len);
+    assert_eq!(expected_line_ending_len, line_endings_len);
+}
+
+pub fn random_config<R: Rng>(rng: &mut R, line_len_range: &Range<usize>) -> Config {
+    let line_wrap = if rng.gen() {
+        LineWrap::NoWrap
+    } else {
+        let line_len = line_len_range.ind_sample(rng);
+
+        let line_ending = if rng.gen() {
+            LineEnding::LF
+        } else {
+            LineEnding::CRLF
+        };
+
+        LineWrap::Wrap(line_len, line_ending)
+    };
+
+    let charset = if rng.gen() {
+        CharacterSet::UrlSafe
+    } else {
+        CharacterSet::Standard
+    };
+
+    Config::new(charset, rng.gen(), rng.gen(), line_wrap)
+}


### PR DESCRIPTION
Builds on #27 to minimize unsafe usage (see discussion in #29 for more context).

This has only a minor performance cost, and on certain sizes, a small boost:

```
 name                    master.bcmp ns/iter    branch.bcmp ns/iter     diff ns/iter  diff % 
 encode_100b             94 (1063 MB/s)          87 (1149 MB/s)                    -7  -7.45% 
 encode_100b_reuse_buf   72 (1388 MB/s)          67 (1492 MB/s)                    -5  -6.94% 
 encode_10mib            8,894,048 (1178 MB/s)   9,030,736 (1161 MB/s)        136,688   1.54% 
 encode_10mib_reuse_buf  5,685,071 (1844 MB/s)   5,991,851 (1750 MB/s)        306,780   5.40% 
 encode_30mib            27,063,216 (1162 MB/s)  27,540,693 (1142 MB/s)       477,477   1.76% 
 encode_30mib_reuse_buf  17,055,237 (1844 MB/s)  18,557,631 (1695 MB/s)     1,502,394   8.81% 
 encode_3b               34 (88 MB/s)            38 (78 MB/s)                       4  11.76% 
 encode_3b_reuse_buf     14 (214 MB/s)           17 (176 MB/s)                      3  21.43% 
 encode_3kib             1,711 (1795 MB/s)       1,634 (1880 MB/s)                -77  -4.50% 
 encode_3kib_reuse_buf   1,691 (1816 MB/s)       1,611 (1906 MB/s)                -80  -4.73% 
 encode_3mib             2,436,637 (1291 MB/s)   2,518,086 (1249 MB/s)         81,449   3.34% 
 encode_3mib_reuse_buf   1,692,495 (1858 MB/s)   1,704,400 (1845 MB/s)         11,905   0.70% 
 encode_500b             313 (1597 MB/s)         294 (1700 MB/s)                  -19  -6.07% 
 encode_500b_reuse_buf   292 (1712 MB/s)         274 (1824 MB/s)                  -18  -6.16% 
 encode_50b              62 (806 MB/s)           61 (819 MB/s)                     -1  -1.61% 
 encode_50b_reuse_buf    42 (1190 MB/s)          41 (1219 MB/s)                    -1  -2.38% 
```

Also, mime (which line wraps) is now only somewhat slower instead of much slower:

```
test encode_3kib_reuse_buf      ... bench:       1,612 ns/iter (+/- 12) = 1905 MB/s
test encode_3kib_reuse_buf_mime ... bench:       2,017 ns/iter (+/- 4) = 1523 MB/s
test encode_500b_reuse_buf      ... bench:         278 ns/iter (+/- 1) = 1798 MB/s
test encode_500b_reuse_buf_mime ... bench:         378 ns/iter (+/- 2) = 1322 MB/s
```