### PR TITLE
Heap-free `Display` wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ safemem = "0.2.0"
 rand = "0.3.15"
 
 [profile.bench]
-# Uncomment when using `perf record`
-#debug = true
+# Useful for better disassembly when using `perf record` and `perf annotate`
+debug = true

--- a/README.md
+++ b/README.md
@@ -64,14 +64,7 @@ cargo run --example make_tables > src/tables.rs.tmp && mv src/tables.rs.tmp src/
 Profiling
 ---
 
-On Linux, you can use [perf](https://perf.wiki.kernel.org/index.php/Main_Page) for profiling. First, enable debug symbols in Cargo.toml. Don't commit this change, though, since it's usually not what you want (and costs some performance):
-
-```
-[profile.release]
-debug = true
-```
-
-Then compile the benchmarks. (Just re-run them and ^C once the benchmarks start running; all that's needed is to recompile them.)
+On Linux, you can use [perf](https://perf.wiki.kernel.org/index.php/Main_Page) for profiling. Then compile the benchmarks with `rustup nightly run cargo bench --no-run`.
 
 Run the benchmark binary with `perf` (shown here filtering to one particular benchmark, which will make the results easier to read). `perf` is only available to the root user on most systems as it fiddles with event counters in your CPU, so use `sudo`. We need to run the actual benchmark binary, hence the path into `target`. You can see the actual full path with `rustup run nightly cargo bench -v`; it will print out the commands it runs. If you use the exact path that `bench` outputs, make sure you get the one that's for the benchmarks, not the tests. You may also want to `cargo clean` so you have only one `benchmarks-` binary (they tend to accumulate).
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 # Next
 
 - `STANDARD_NO_PAD` config
+- `Base64Display` heap-free wrapper for use in format strings, etc
 
 # 0.6.0
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -5,6 +5,7 @@ extern crate test;
 extern crate rand;
 
 use base64::{decode, decode_config_buf, encode, encode_config_buf, Config, MIME, STANDARD};
+use base64::display;
 
 use test::Bencher;
 use rand::Rng;
@@ -60,6 +61,11 @@ fn encode_3kib(b: &mut Bencher) {
 }
 
 #[bench]
+fn encode_3kib_display(b: &mut Bencher) {
+    do_encode_bench_display(b, 3 * 1024)
+}
+
+#[bench]
 fn encode_3kib_reuse_buf(b: &mut Bencher) {
     do_encode_bench_reuse_buf(b, 3 * 1024, STANDARD)
 }
@@ -72,6 +78,11 @@ fn encode_3kib_reuse_buf_mime(b: &mut Bencher) {
 #[bench]
 fn encode_3mib(b: &mut Bencher) {
     do_encode_bench(b, 3 * 1024 * 1024)
+}
+
+#[bench]
+fn encode_3mib_display(b: &mut Bencher) {
+    do_encode_bench_display(b, 3 * 1024 * 1024)
 }
 
 #[bench]
@@ -212,6 +223,17 @@ fn do_encode_bench(b: &mut Bencher, size: usize) {
     b.bytes = v.len() as u64;
     b.iter(|| {
         let e = encode(&v);
+        test::black_box(&e);
+    });
+}
+
+fn do_encode_bench_display(b: &mut Bencher, size: usize) {
+    let mut v: Vec<u8> = Vec::with_capacity(size);
+    fill(&mut v);
+
+    b.bytes = v.len() as u64;
+    b.iter(|| {
+        let e = format!("{}", display::Base64Display::new(&v));
         test::black_box(&e);
     });
 }

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,0 +1,427 @@
+use super::{Config, LineWrap, LineEnding, encode_to_slice, add_padding};
+use super::line_wrap::line_wrap;
+use std::{cmp, str};
+
+pub trait Sink {
+    type Error;
+
+    fn write_str(&mut self, &str) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ChunkedEncoderError {
+    /// If wrapping is configured, the line length must be a multiple of 4, and must not be absurdly
+    /// large (see BUF_SIZE).
+    InvalidLineLength,
+}
+
+const BUF_SIZE: usize = 1024;
+
+/// A base64 encoder that emits encoded bytes in chunks without heap allocation.
+pub struct ChunkedEncoder {
+    config: Config,
+    max_input_chunk_len: usize,
+}
+
+impl ChunkedEncoder {
+    pub fn new(config: Config) -> Result<ChunkedEncoder, ChunkedEncoderError> {
+        Ok(ChunkedEncoder {
+            config: config,
+            max_input_chunk_len: max_input_length(BUF_SIZE, &config)?,
+        })
+    }
+
+    pub fn encode<S: Sink>(&self, bytes: &[u8], sink: &mut S) -> Result<(), S::Error> {
+        let mut encode_buf: [u8; BUF_SIZE] = [0; BUF_SIZE];
+        let encode_table = self.config.char_set.encode_table();
+
+        let mut input_index = 0;
+
+        while input_index < bytes.len() {
+            // either the full input chunk size, or it's the last iteration
+            let input_chunk_len = cmp::min(self.max_input_chunk_len,
+                                           bytes.len() - input_index);
+
+            let chunk = &bytes[input_index..(input_index + input_chunk_len)];
+
+            let mut b64_bytes_written = encode_to_slice(chunk, &mut encode_buf, encode_table);
+
+            input_index += input_chunk_len;
+            let more_input_left = input_index < bytes.len();
+
+            if self.config.pad && !more_input_left {
+                // no more input, add padding if needed. Buffer will have room because
+                // max_input_length leaves room for it.
+                b64_bytes_written += add_padding(bytes.len(), &mut encode_buf[b64_bytes_written..]);
+            }
+
+            let line_ending_bytes = match self.config.line_wrap {
+                LineWrap::NoWrap => 0,
+                LineWrap::Wrap(line_len, line_ending) => {
+                    let initial_line_ending_bytes =
+                        line_wrap(&mut encode_buf, b64_bytes_written, line_len, line_ending);
+
+                    if more_input_left {
+                        assert_eq!(input_chunk_len, self.max_input_chunk_len);
+                        // If there are more bytes of input, then we know we didn't just do the
+                        // last chunk. line_wrap() doesn't put an ending after the last line, so we
+                        // append one more line ending here. Since the chunk just encoded was not
+                        // the last one, it was multiple of the line length (max_input_chunk_len),
+                        // and therefore we can just put the line ending bytes at the end of the
+                        // contents of the buffer.
+                        match line_ending {
+                            LineEnding::LF => {
+                                encode_buf[b64_bytes_written + initial_line_ending_bytes] = b'\n';
+                                initial_line_ending_bytes + 1
+                            }
+                            LineEnding::CRLF => {
+                                encode_buf[b64_bytes_written + initial_line_ending_bytes] = b'\r';
+                                encode_buf[b64_bytes_written + initial_line_ending_bytes + 1] = b'\n';
+                                initial_line_ending_bytes + 2
+                            }
+                        }
+                    } else {
+                        initial_line_ending_bytes
+                    }
+                }
+            };
+
+            let total_bytes_written = b64_bytes_written + line_ending_bytes;
+
+            // all base64 bytes are valid utf8
+            let s = unsafe { str::from_utf8_unchecked(&encode_buf[0..total_bytes_written]) };
+
+            sink.write_str(s)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Calculate the longest input that can be encoded for the given output buffer size.
+///
+/// If config requires line wrap, the calculated input length will be the maximum number of input
+/// lines that can fit in the output buffer after each line has had its line ending appended.
+///
+/// If the config requires padding, two bytes of buffer space will be set aside so that the last
+/// chunk of input can be encoded safely.
+///
+/// The input length will always be a multiple of 3 so that no encoding state has to be carried over
+/// between chunks.
+///
+/// If the configured line length is not divisible by 4 (and therefore would require carrying
+/// encoder state between chunks), or if the line length is too big for the buffer, None will be
+/// returned.
+///
+/// Note that the last overall line of input should *not* have an ending appended, but this will
+/// conservatively calculate space as if it should because encoding is done in chunks, and all the
+/// chunks before the last one will need a line ending after the last encoded line in that chunk.
+fn max_input_length(encoded_buf_len: usize, config: &Config) -> Result<usize, ChunkedEncoderError> {
+
+    let effective_buf_len = if config.pad {
+        // make room for padding
+        encoded_buf_len.checked_sub(2).expect("Don't use a tiny buffer")
+    } else {
+        encoded_buf_len
+    };
+
+    match config.line_wrap {
+        // No wrapping, no padding, so just normal base64 expansion.
+        LineWrap::NoWrap => Ok((effective_buf_len / 4) * 3),
+        LineWrap::Wrap(line_len, line_ending) => {
+            // To avoid complicated encode buffer shuffling, only allow line lengths that are
+            // multiples of 4 (which map to input lengths that are multiples of 3).
+            // line_len is never 0.
+            if line_len % 4 != 0 {
+                return Err(ChunkedEncoderError::InvalidLineLength);
+            }
+
+            let single_encoded_full_line_with_ending_len = line_len.checked_add(line_ending.len())
+                .expect("Encoded line length with ending exceeds usize");
+
+            // max number of complete lines with endings that will fit in buffer
+            let num_encoded_wrapped_lines_in_buffer =
+                effective_buf_len / single_encoded_full_line_with_ending_len;
+
+            if num_encoded_wrapped_lines_in_buffer == 0 {
+                // line + ending is longer than can fit into encode buffer; give up
+                Err(ChunkedEncoderError::InvalidLineLength)
+            } else {
+                let input_len_for_line_len = (line_len / 4) * 3;
+
+                let input_len = input_len_for_line_len
+                    .checked_mul(num_encoded_wrapped_lines_in_buffer)
+                    .expect("Max input size exceeds usize");
+
+                assert!(input_len % 3 == 0 && input_len > 1);
+
+                Ok(input_len)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    extern crate rand;
+
+    use super::super::*;
+    use super::super::tests::random_config;
+    use super::*;
+
+    use self::rand::Rng;
+    use self::rand::distributions::{IndependentSample, Range};
+
+    #[test]
+    fn chunked_encode_empty() {
+        assert_eq!("", chunked_encode_str(&[], STANDARD));
+    }
+
+    #[test]
+    fn chunked_encode_fast_loop_only() {
+        // > 8 bytes input, will enter fast loop
+        assert_eq!("Zm9vYmFyYmF6cXV4", chunked_encode_str("foobarbazqux".as_bytes(), STANDARD));
+    }
+
+    #[test]
+    fn chunked_encode_slow_loop_only() {
+        // < 8 bytes input, slow loop only
+        assert_eq!("Zm9vYmFy", chunked_encode_str("foobar".as_bytes(), STANDARD));
+    }
+
+    #[test]
+    fn chunked_encode_line_wrap_padding() {
+        // < 8 bytes input, slow loop only
+        let config = config_wrap(true, 4, LineEnding::LF);
+        assert_eq!("Zm9v\nYmFy\nZm9v\nYmFy\nZg==", chunked_encode_str("foobarfoobarf".as_bytes(), config));
+    }
+
+    #[test]
+    fn chunked_encode_matches_normal_encode_random_string_sink() {
+        let helper = StringSinkTestHelper;
+        chunked_encode_matches_normal_encode_random(&helper);
+    }
+
+    #[test]
+    fn max_input_length_no_wrap_no_pad() {
+        let config = config_no_wrap(false);
+        assert_eq!(768, max_input_length(1024, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_no_wrap_with_pad_decrements_one_triple() {
+        let config = config_no_wrap(true);
+        assert_eq!(765, max_input_length(1024, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_no_wrap_with_pad_one_byte_short() {
+        let config = config_no_wrap(true);
+        assert_eq!(765, max_input_length(1025, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_no_wrap_with_pad_fits_exactly() {
+        let config = config_no_wrap(true);
+        assert_eq!(768, max_input_length(1026, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_fits_exactly_no_pad() {
+        // 10 * (72 + 1) = 730. 54 input bytes = 72 encoded bytes, + 1 for LF.
+        let config = config_wrap(false, 72, LineEnding::LF);
+        assert_eq!(540, max_input_length(730, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_fits_one_spare_byte_no_pad() {
+        // 10 * (72 + 1) = 730. 54 input bytes = 72 encoded bytes, + 1 for LF.
+        let config = config_wrap(false, 72, LineEnding::LF);
+        assert_eq!(540, max_input_length(731, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_size_one_byte_short_of_another_line_no_pad() {
+        // 10 * (72 + 1) = 730. 54 input bytes = 72 encoded bytes, + 1 for LF.
+        // 73 * 11 = 803
+        let config = config_wrap(false, 72, LineEnding::LF);
+        assert_eq!(540, max_input_length(802, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_size_another_line_no_pad() {
+        // 10 * (72 + 1) = 730. 54 input bytes = 72 encoded bytes, + 1 for LF.
+        // 73 * 11 = 803
+        let config = config_wrap(false, 72, LineEnding::LF);
+        assert_eq!(594, max_input_length(803, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_one_byte_short_with_pad() {
+        // one fewer input line
+        let config = config_wrap(true, 72, LineEnding::LF);
+        assert_eq!(486, max_input_length(731, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_lf_fits_exactly_with_pad() {
+        // 10 * (72 + 1) = 730. 54 input bytes = 72 encoded bytes, + 1 for LF.
+        let config = config_wrap(true, 72, LineEnding::LF);
+        assert_eq!(540, max_input_length(732, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_line_len_wont_fit_one_line_lf() {
+        // 300 bytes is 400 encoded, + 1 for LF
+        let config = config_wrap(false, 400, LineEnding::LF);
+        assert_eq!(ChunkedEncoderError::InvalidLineLength,
+            max_input_length(400, &config).unwrap_err());
+    }
+
+    #[test]
+    fn max_input_length_wrap_line_len_just_fits_one_line_lf() {
+        // 300 bytes is 400 encoded, + 1 for LF
+        let config = Config::new(CharacterSet::Standard, false, false,
+                                 LineWrap::Wrap(400, LineEnding::LF));
+        assert_eq!(300, max_input_length(401, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_crlf_fits_exactly_no_pad() {
+        // 10 * (72 + 2) = 740. 54 input bytes = 72 encoded bytes, + 2 for CRLF.
+        let config = config_wrap(false, 72, LineEnding::CRLF);
+        assert_eq!(540, max_input_length(740, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_crlf_fits_one_spare_byte_no_pad() {
+        // 10 * (72 + 2) = 740. 54 input bytes = 72 encoded bytes, + 2 for CRLF.
+        let config = config_wrap(false, 72, LineEnding::CRLF);
+        assert_eq!(540, max_input_length(741, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_crlf_size_one_byte_short_of_another_line_no_pad() {
+        // 10 * (72 + 2) = 740. 54 input bytes = 72 encoded bytes, + 2 for CRLF.
+        // 74 * 11 = 814
+        let config = config_wrap(false, 72, LineEnding::CRLF);
+        assert_eq!(540, max_input_length(813, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_with_crlf_size_another_line_no_pad() {
+        // 10 * (72 + 2) = 740. 54 input bytes = 72 encoded bytes, + 2 for CRLF.
+        // 74 * 11 = 814
+        let config = config_wrap(false, 72, LineEnding::CRLF);
+        assert_eq!(594, max_input_length(814, &config).unwrap());
+    }
+
+    #[test]
+    fn max_input_length_wrap_line_len_not_multiple_of_4_rejected() {
+        let config = config_wrap(false, 41, LineEnding::LF);
+        assert_eq!(ChunkedEncoderError::InvalidLineLength, max_input_length(400, &config).unwrap_err());
+    }
+
+    pub fn chunked_encode_matches_normal_encode_random<S: SinkTestHelper>(sink_test_helper: &S) {
+        let mut input_buf: Vec<u8> = Vec::new();
+        let mut output_buf = String::new();
+        let mut rng = rand::weak_rng();
+        let line_len_range = Range::new(10, 100);
+        let input_len_range = Range::new(2, 10_000);
+
+        for _ in 0..2_000 {
+            input_buf.clear();
+            output_buf.clear();
+
+            let buf_len = input_len_range.ind_sample(&mut rng);
+            for _ in 0..buf_len {
+                input_buf.push(rng.gen());
+            }
+
+            let config = random_config_for_chunked_encoder(&mut rng, &line_len_range);
+
+            let chunk_encoded_string = sink_test_helper.encode_to_string(config, &input_buf);
+            encode_config_buf(&input_buf, config, &mut output_buf);
+
+            assert_eq!(output_buf, chunk_encoded_string, "input len={}, config: pad={}, wrap={:?}",
+                buf_len, config.pad, config.line_wrap);
+        }
+    }
+
+    fn chunked_encode_str(bytes: &[u8], config: Config) -> String {
+        let mut sink = StringSink::new();
+
+        {
+            let encoder = ChunkedEncoder::new(config).unwrap();
+            encoder.encode(bytes, &mut sink).unwrap();
+        }
+
+        return sink.string;
+    }
+
+    fn random_config_for_chunked_encoder<R: Rng>(rng: &mut R, line_len_range: &Range<usize>) -> Config{
+        loop {
+            let config = random_config(rng, line_len_range);
+
+            // only use a config with line_len that is divisible by 4
+            match config.line_wrap {
+                LineWrap::NoWrap => return config,
+                LineWrap::Wrap(line_len, _) => {
+                    if line_len % 4 == 0 {
+                        return config;
+                    }
+                }
+            }
+        }
+    }
+
+    fn config_no_wrap(pad: bool) -> Config {
+        Config::new(CharacterSet::Standard, pad, false, LineWrap::NoWrap)
+    }
+
+    fn config_wrap(pad: bool, line_len: usize, line_ending: LineEnding) -> Config {
+        Config::new(CharacterSet::Standard, pad, false, LineWrap::Wrap(line_len, line_ending))
+    }
+
+    // An abstraction around sinks so that we can have tests that easily to any sink implementation
+    pub trait SinkTestHelper {
+        fn encode_to_string(&self, config: Config, bytes: &[u8]) -> String;
+    }
+
+    // A really simple sink that just appends to a string for testing
+    struct StringSink {
+        string: String
+    }
+
+    impl StringSink {
+        fn new() -> StringSink {
+            StringSink {
+                string: String::new()
+            }
+        }
+    }
+
+    impl Sink for StringSink {
+        type Error = ();
+
+        fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+            self.string.push_str(s);
+
+            Ok(())
+        }
+    }
+
+    struct StringSinkTestHelper;
+
+    impl SinkTestHelper for StringSinkTestHelper {
+        fn encode_to_string(&self, config: Config, bytes: &[u8]) -> String {
+            let encoder = ChunkedEncoder::new(config).unwrap();
+            let mut sink = StringSink::new();
+
+            encoder.encode(bytes, &mut sink).unwrap();
+
+            sink.string
+        }
+    }
+
+}

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -377,7 +377,7 @@ pub mod tests {
         let mut input_buf: Vec<u8> = Vec::new();
         let mut output_buf = String::new();
         let mut rng = rand::weak_rng();
-        let line_len_range = Range::new(1, 1000);
+        let line_len_range = Range::new(1, 1020);
         let input_len_range = Range::new(1, 10_000);
 
         for _ in 0..5_000 {

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,6 +1,6 @@
 use super::{Config, LineWrap, LineEnding, encode_to_slice, add_padding};
 use super::line_wrap::line_wrap;
-use std::{cmp, str};
+use std::cmp;
 
 /// The output mechanism for ChunkedEncoder's encoded bytes.
 pub trait Sink {
@@ -28,7 +28,7 @@ pub struct ChunkedEncoder {
 impl ChunkedEncoder {
     pub fn new(config: Config) -> Result<ChunkedEncoder, ChunkedEncoderError> {
         Ok(ChunkedEncoder {
-            config: config,
+            config,
             max_input_chunk_len: max_input_length(BUF_SIZE, &config)?,
         })
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -17,7 +17,7 @@ impl<'a> Base64Display<'a> {
 
     fn new_with_config(bytes: &[u8], config: Config) -> Result<Base64Display, ChunkedEncoderError> {
         ChunkedEncoder::new(config).map( |c| Base64Display {
-            bytes: bytes,
+            bytes,
             chunked_encoder: c
         })
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,0 +1,71 @@
+use super::{STANDARD, Config};
+use super::chunked_encoder::{ChunkedEncoder, ChunkedEncoderError};
+use std::fmt::{Display, Formatter};
+use std::fmt;
+
+/// A convenience wrapper for base64'ing bytes into a format string without heap allocation.
+pub struct Base64Display<'a> {
+    bytes: &'a [u8],
+    chunked_encoder: ChunkedEncoder
+}
+
+impl<'a> Base64Display<'a> {
+    /// Create a Base64Display with default base64 configuration: no line wrapping, with padding.
+    pub fn new(bytes: &[u8]) -> Base64Display {
+        Self::new_with_config(bytes, STANDARD).expect("STANDARD is always ok")
+    }
+
+    fn new_with_config(bytes: &[u8], config: Config) -> Result<Base64Display, ChunkedEncoderError> {
+        ChunkedEncoder::new(config).map( |c| Base64Display {
+            bytes: bytes,
+            chunked_encoder: c
+        })
+    }
+}
+
+impl<'a> Display for Base64Display<'a> {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
+        let mut sink = FormatterSink { f: formatter };
+        self.chunked_encoder.encode(self.bytes, &mut sink)
+    }
+}
+
+struct FormatterSink<'a, 'b: 'a> {
+    f: &'a mut Formatter<'b>
+}
+
+impl<'a, 'b: 'a> super::chunked_encoder::Sink for FormatterSink<'a, 'b> {
+    type Error = fmt::Error;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.f.write_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::*;
+    use super::super::chunked_encoder::tests::{SinkTestHelper, chunked_encode_matches_normal_encode_random};
+
+    #[test]
+    fn basic_display() {
+        assert_eq!("~$Zm9vYmFy#*", format!("~${}#*", Base64Display::new("foobar".as_bytes())));
+        assert_eq!("~$Zm9vYmFyZg==#*", format!("~${}#*", Base64Display::new("foobarf".as_bytes())));
+    }
+
+    #[test]
+    fn display_encode_matches_normal_encode() {
+        let helper = DisplaySinkTestHelper;
+        chunked_encode_matches_normal_encode_random(&helper);
+    }
+
+    struct DisplaySinkTestHelper;
+
+    impl SinkTestHelper for DisplaySinkTestHelper {
+        fn encode_to_string(&self, config: Config, bytes: &[u8]) -> String {
+            format!("{}", Base64Display::new_with_config(bytes, config).unwrap())
+        }
+    }
+
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use super::{STANDARD, Config};
 use super::chunked_encoder::{ChunkedEncoder, ChunkedEncoderError};
 use std::fmt::{Display, Formatter};
-use std::fmt;
+use std::{fmt, str};
 
 /// A convenience wrapper for base64'ing bytes into a format string without heap allocation.
 pub struct Base64Display<'a> {
@@ -37,8 +37,10 @@ struct FormatterSink<'a, 'b: 'a> {
 impl<'a, 'b: 'a> super::chunked_encoder::Sink for FormatterSink<'a, 'b> {
     type Error = fmt::Error;
 
-    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.f.write_str(s)
+    fn write_encoded_bytes(&mut self, encoded: &[u8]) -> Result<(), Self::Error> {
+        // Avoid unsafe. If max performance is needed, write your own display wrapper that uses
+        // unsafe here to gain about 10-15%.
+        self.f.write_str(str::from_utf8(encoded).expect("base64 data was not utf8"))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@ use std::{fmt, error, str};
 
 use byteorder::{BigEndian, ByteOrder};
 
+pub mod display;
 mod tables;
-
+mod chunked_encoder;
 mod line_wrap;
+
 use line_wrap::{line_wrap_parameters, line_wrap};
 
 /// Available encoding character sets

--- a/src/line_wrap.rs
+++ b/src/line_wrap.rs
@@ -2,8 +2,6 @@ extern crate safemem;
 
 use super::*;
 
-use std::str;
-
 #[derive(Debug, PartialEq)]
 pub struct LineWrapParameters {
     // number of lines that need an ending
@@ -140,7 +138,6 @@ pub fn line_wrap(encoded_buf: &mut [u8], input_len: usize, line_len: usize, line
 mod tests {
     extern crate rand;
 
-    use super::super::*;
     use super::*;
 
     use self::rand::Rng;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -443,6 +443,19 @@ fn encode_line_ending_crlf_full_last_line() {
 }
 
 #[test]
+fn display_wrapper_matches_normal_encode() {
+
+    let mut bytes = Vec::<u8>::with_capacity(256);
+
+    for i in 0..255 {
+        bytes.push(i);
+    }
+    bytes.push(255);
+
+    assert_eq!(encode(&bytes), format!("{}", base64::display::Base64Display::new(&bytes)));
+}
+
+#[test]
 fn because_we_can() {
     compare_decode("alice", "YWxpY2U=");
     compare_decode("alice", &encode(b"alice"));


### PR DESCRIPTION
As per #17. @tailhook does this meet your needs? It encodes into a stack-resident buffer, then hands off the encoded data to the `Formatter` provided to `Display`.

There is a nontrivial but not overhwhelming performance cost for going through the `ChunkedEncoder` mechanism:

```
test encode_3kib                ... bench:       1,639 ns/iter (+/- 77) = 1874 MB/s
test encode_3kib_display        ... bench:       1,987 ns/iter (+/- 403) = 1546 MB/s
test encode_3mib                ... bench:   2,583,661 ns/iter (+/- 110,524) = 1217 MB/s
test encode_3mib_display        ... bench:   2,884,784 ns/iter (+/- 165,993) = 1090 MB/s
```

Also, I'm open to different names. As it currently is, I think typical usage would look like:

```
println!("Have some base64: {}", Base64Display::new(&some_bytes));
```

This opens the door to #20, at least for the encode path.