### PR TITLE
Update Cargo license marker (MIT/Apache-2.0).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://github.com/alicemaz/rust-base64/blob/master/README.md"
 readme = "README.md"
 keywords = ["base64", "utf8", "encode", "decode"]
 categories = ["encoding"]
-license = "MIT"
+license = "MIT/Apache-2.0"
 
 [dependencies]
 byteorder = "1.0.0"


### PR DESCRIPTION
The repository and the README show that this crate is dual-licensed under MIT and Apache 2.0, however the Cargo.toml file says only MIT. This commit updates the Cargo.toml to match the README.