### PR TITLE
Link to the documentation on docs.rs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [base64](https://crates.io/crates/base64)
 ===
+[![Docs](https://docs.rs/base64/badge.svg)](https://docs.rs/base64)
 
 It's base64. What more could anyone want?
 


### PR DESCRIPTION
At least for me I often want to navigate directly to the docs from the repository so I find it useful to have a link directly to them!