### PR TITLE
Display wrapper API changes

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,7 @@
 //! use base64::display::Base64Display;
 //!
 //! let data = vec![0x0, 0x1, 0x2, 0x3];
-//! let wrapper = Base64Display::new(&data, STANDARD).expect("STANDARD is OK");
+//! let wrapper = Base64Display::standard(&data);
 //!
 //! assert_eq!("base64: AAECAw==", format!("base64: {}", wrapper));
 //! ```
@@ -32,8 +32,8 @@ pub struct Base64Display<'a> {
 }
 
 impl<'a> Base64Display<'a> {
-    /// Create a Base64Display with the provided config.
-    pub fn new(bytes: &[u8], config: Config) -> Result<Base64Display, DisplayError> {
+    /// Create a `Base64Display` with the provided config.
+    pub fn with_config(bytes: &[u8], config: Config) -> Result<Base64Display, DisplayError> {
         ChunkedEncoder::new(config)
                 .map( |c| Base64Display {
                     bytes,
@@ -43,6 +43,17 @@ impl<'a> Base64Display<'a> {
                     ChunkedEncoderError::InvalidLineLength => DisplayError::InvalidLineLength
                 })
     }
+
+    /// Convenience method for creating a `Base64Display` with the `STANDARD` configuration.
+    pub fn standard(bytes: &[u8]) -> Base64Display {
+        Base64Display::with_config(bytes, super::STANDARD).expect("STANDARD is valid")
+    }
+
+    /// Convenience method for creating a `Base64Display` with the `URL_SAFE` configuration.
+    pub fn url_safe(bytes: &[u8]) -> Base64Display {
+        Base64Display::with_config(bytes, super::URL_SAFE).expect("URL_SAFE is valid")
+    }
+
 }
 
 impl<'a> Display for Base64Display<'a> {
@@ -74,8 +85,8 @@ mod tests {
 
     #[test]
     fn basic_display() {
-        assert_eq!("~$Zm9vYmFy#*", format!("~${}#*", Base64Display::new("foobar".as_bytes(), STANDARD).unwrap()));
-        assert_eq!("~$Zm9vYmFyZg==#*", format!("~${}#*", Base64Display::new("foobarf".as_bytes(), STANDARD).unwrap()));
+        assert_eq!("~$Zm9vYmFy#*", format!("~${}#*", Base64Display::standard("foobar".as_bytes())));
+        assert_eq!("~$Zm9vYmFyZg==#*", format!("~${}#*", Base64Display::standard("foobarf".as_bytes())));
     }
 
     #[test]
@@ -88,7 +99,7 @@ mod tests {
 
     impl SinkTestHelper for DisplaySinkTestHelper {
         fn encode_to_string(&self, config: Config, bytes: &[u8]) -> String {
-            format!("{}", Base64Display::new(bytes, config).unwrap())
+            format!("{}", Base64Display::with_config(bytes, config).unwrap())
         }
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,29 @@
-use super::{STANDARD, Config};
+//! Enables base64'd output anywhere you might use a Display implementation, like a format string.
+//!
+//! ```
+//! use base64::STANDARD;
+//! use base64::display::Base64Display;
+//!
+//! let data = vec![0x0, 0x1, 0x2, 0x3];
+//! let wrapper = Base64Display::new(&data, STANDARD).expect("STANDARD is OK");
+//!
+//! assert_eq!("base64: AAECAw==", format!("base64: {}", wrapper));
+//! ```
+
+use super::Config;
 use super::chunked_encoder::{ChunkedEncoder, ChunkedEncoderError};
 use std::fmt::{Display, Formatter};
 use std::{fmt, str};
+
+// I'm not convinced that we should expose ChunkedEncoder or its error type since it's just an
+// implementation detail, so use a different error type.
+/// Errors that can occur initializing a Base64Display.
+#[derive(Debug, PartialEq)]
+pub enum DisplayError {
+    /// If wrapping is configured, the line length must be a multiple of 4, and must not be absurdly
+    /// large (currently capped at 1024, subject to change).
+    InvalidLineLength,
+}
 
 /// A convenience wrapper for base64'ing bytes into a format string without heap allocation.
 pub struct Base64Display<'a> {
@@ -10,16 +32,16 @@ pub struct Base64Display<'a> {
 }
 
 impl<'a> Base64Display<'a> {
-    /// Create a Base64Display with default base64 configuration: no line wrapping, with padding.
-    pub fn new(bytes: &[u8]) -> Base64Display {
-        Self::new_with_config(bytes, STANDARD).expect("STANDARD is always ok")
-    }
-
-    fn new_with_config(bytes: &[u8], config: Config) -> Result<Base64Display, ChunkedEncoderError> {
-        ChunkedEncoder::new(config).map( |c| Base64Display {
-            bytes,
-            chunked_encoder: c
-        })
+    /// Create a Base64Display with the provided config.
+    pub fn new(bytes: &[u8], config: Config) -> Result<Base64Display, DisplayError> {
+        ChunkedEncoder::new(config)
+                .map( |c| Base64Display {
+                    bytes,
+                    chunked_encoder: c
+                })
+                .map_err(|e| match e {
+                    ChunkedEncoderError::InvalidLineLength => DisplayError::InvalidLineLength
+                })
     }
 }
 
@@ -52,8 +74,8 @@ mod tests {
 
     #[test]
     fn basic_display() {
-        assert_eq!("~$Zm9vYmFy#*", format!("~${}#*", Base64Display::new("foobar".as_bytes())));
-        assert_eq!("~$Zm9vYmFyZg==#*", format!("~${}#*", Base64Display::new("foobarf".as_bytes())));
+        assert_eq!("~$Zm9vYmFy#*", format!("~${}#*", Base64Display::new("foobar".as_bytes(), STANDARD).unwrap()));
+        assert_eq!("~$Zm9vYmFyZg==#*", format!("~${}#*", Base64Display::new("foobarf".as_bytes(), STANDARD).unwrap()));
     }
 
     #[test]
@@ -66,7 +88,7 @@ mod tests {
 
     impl SinkTestHelper for DisplaySinkTestHelper {
         fn encode_to_string(&self, config: Config, bytes: &[u8]) -> String {
-            format!("{}", Base64Display::new_with_config(bytes, config).unwrap())
+            format!("{}", Base64Display::new(bytes, config).unwrap())
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -452,7 +452,7 @@ fn display_wrapper_matches_normal_encode() {
     }
     bytes.push(255);
 
-    assert_eq!(encode(&bytes), format!("{}", base64::display::Base64Display::new(&bytes, STANDARD).unwrap()));
+    assert_eq!(encode(&bytes), format!("{}", base64::display::Base64Display::standard(&bytes)));
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -452,7 +452,7 @@ fn display_wrapper_matches_normal_encode() {
     }
     bytes.push(255);
 
-    assert_eq!(encode(&bytes), format!("{}", base64::display::Base64Display::new(&bytes)));
+    assert_eq!(encode(&bytes), format!("{}", base64::display::Base64Display::new(&bytes, STANDARD).unwrap()));
 }
 
 #[test]


### PR DESCRIPTION
While I have the opportunity to tweak this API before I release it... I just really don't like murky default choices that people will use without thinking. I figure people can make a helper function easily enough if they consistently use the same configuration.

@tailhook would this meet your needs?