### PR TITLE
Add an `encode_config_slice` method to write to slices

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -365,6 +365,68 @@ fn add_padding_random_valid_utf8(){
     }
 }
 
+#[test]
+fn encode_config_slice_can_use_inline_buffer() {
+    let mut buf: [u8; 22] = [0; 22];
+    let mut larger_buf: [u8; 24] = [0; 24];
+    let mut input: [u8; 16] = [0; 16];
+
+    let mut rng = rand::weak_rng();
+    for elt in &mut input {
+        *elt = rng.gen();
+    }
+
+    let config = Config::new(
+        CharacterSet::Standard,
+        false,
+        true,
+        LineWrap::NoWrap,
+    );
+
+    encode_config_slice(&input, config, &mut buf);
+    let decoded = decode_config(&buf, config).unwrap();
+
+    assert_eq!(decoded, input);
+
+    // let's try it again with padding
+    let config_pad = Config::new(
+        CharacterSet::Standard,
+        true,
+        true,
+        LineWrap::NoWrap,
+    );
+
+    encode_config_slice(&input, config_pad, &mut larger_buf);
+    let decoded = decode_config(&buf, config_pad).unwrap();
+
+    assert_eq!(decoded, input);
+}
+
+#[test]
+#[should_panic]
+fn encode_config_slice_panics_when_buffer_too_small() {
+    let mut buf: [u8; 22] = [0; 22];
+    let mut input: [u8; 16] = [0; 16];
+
+    let mut rng = rand::weak_rng();
+    for elt in &mut input {
+        *elt = rng.gen();
+    }
+
+    // let's try it again with padding
+    let config_pad = Config::new(
+        CharacterSet::Standard,
+        true,
+        true,
+        LineWrap::NoWrap,
+    );
+
+    encode_config_slice(&input, config_pad, &mut buf);
+    let decoded = decode_config(&buf, config_pad).unwrap();
+
+    assert_eq!(decoded, input);
+}
+
 fn total_line_ending_bytes(encoded_len: usize, config: &Config) -> usize {
     match config.line_wrap {
         LineWrap::NoWrap => 0,


### PR DESCRIPTION
The obvious point of this is to write to ungrowable slices and arrays.

For my case, I have some content that I can stick into the guaranteed
stack-allocated portion of an InlineString, which is pretty nice.

The idea for this came up for me because I want to serialize UUIDs to 
Base64, which has a really small encoded representation.

In case you're curious, here the commit where I implement the inline 
serialization:
https://github.com/quodlibetor/b64-ids/commit/87dd8d1de4da18d5b0b72e80900a446524ffbf65