### PR TITLE
Decode slice

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,7 +4,7 @@ extern crate base64;
 extern crate rand;
 extern crate test;
 
-use base64::{decode, decode_config_buf, decode_config_slice, encode, encode_config_buf, Config, MIME, STANDARD};
+use base64::{decode, decode_config_buf, decode_config_slice, encode, encode_config_buf, encode_config_slice, Config, MIME, STANDARD};
 use base64::display;
 
 use test::Bencher;
@@ -21,6 +21,11 @@ fn encode_3b_reuse_buf(b: &mut Bencher) {
 }
 
 #[bench]
+fn encode_3b_slice(b: &mut Bencher) {
+    do_encode_bench_slice(b, 3, STANDARD)
+}
+
+#[bench]
 fn encode_50b(b: &mut Bencher) {
     do_encode_bench(b, 50)
 }
@@ -33,6 +38,11 @@ fn encode_50b_display(b: &mut Bencher) {
 #[bench]
 fn encode_50b_reuse_buf(b: &mut Bencher) {
     do_encode_bench_reuse_buf(b, 50, STANDARD)
+}
+
+#[bench]
+fn encode_50b_slice(b: &mut Bencher) {
+    do_encode_bench_slice(b, 50, STANDARD)
 }
 
 #[bench]
@@ -76,6 +86,11 @@ fn encode_3kib_reuse_buf(b: &mut Bencher) {
 }
 
 #[bench]
+fn encode_3kib_slice(b: &mut Bencher) {
+    do_encode_bench_slice(b, 3 * 1024, STANDARD)
+}
+
+#[bench]
 fn encode_3kib_reuse_buf_mime(b: &mut Bencher) {
     do_encode_bench_reuse_buf(b, 3 * 1024, MIME)
 }
@@ -96,6 +111,11 @@ fn encode_3mib_reuse_buf(b: &mut Bencher) {
 }
 
 #[bench]
+fn encode_3mib_slice(b: &mut Bencher) {
+    do_encode_bench_slice(b, 3 * 1024 * 1024, STANDARD)
+}
+
+#[bench]
 fn encode_10mib(b: &mut Bencher) {
     do_encode_bench(b, 10 * 1024 * 1024)
 }
@@ -113,6 +133,11 @@ fn encode_30mib(b: &mut Bencher) {
 #[bench]
 fn encode_30mib_reuse_buf(b: &mut Bencher) {
     do_encode_bench_reuse_buf(b, 30 * 1024 * 1024, STANDARD)
+}
+
+#[bench]
+fn encode_30mib_slice(b: &mut Bencher) {
+    do_encode_bench_slice(b, 30 * 1024 * 1024, STANDARD)
 }
 
 #[bench]
@@ -292,6 +317,20 @@ fn do_encode_bench_reuse_buf(b: &mut Bencher, size: usize, config: Config) {
     b.iter(|| {
         encode_config_buf(&v, config, &mut buf);
         buf.clear();
+    });
+}
+
+fn do_encode_bench_slice(b: &mut Bencher, size: usize, config: Config) {
+    let mut v: Vec<u8> = Vec::with_capacity(size);
+    fill(&mut v);
+
+    let mut buf = Vec::new();
+
+    b.bytes = v.len() as u64;
+    // conservative estimate of encoded size
+    buf.resize(size * 2, 0);
+    b.iter(|| {
+        encode_config_slice(&v, config, &mut buf);
     });
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,7 +4,7 @@ extern crate base64;
 extern crate rand;
 extern crate test;
 
-use base64::{decode, decode_config_buf, encode, encode_config_buf, Config, MIME, STANDARD};
+use base64::{decode, decode_config_buf, decode_config_slice, encode, encode_config_buf, Config, MIME, STANDARD};
 use base64::display;
 
 use test::Bencher;
@@ -126,6 +126,11 @@ fn decode_3b_reuse_buf(b: &mut Bencher) {
 }
 
 #[bench]
+fn decode_3b_slice(b: &mut Bencher) {
+    do_decode_bench_slice(b, 3)
+}
+
+#[bench]
 fn decode_50b(b: &mut Bencher) {
     do_decode_bench(b, 50)
 }
@@ -133,6 +138,11 @@ fn decode_50b(b: &mut Bencher) {
 #[bench]
 fn decode_50b_reuse_buf(b: &mut Bencher) {
     do_decode_bench_reuse_buf(b, 50)
+}
+
+#[bench]
+fn decode_50b_slice(b: &mut Bencher) {
+    do_decode_bench_slice(b, 50)
 }
 
 #[bench]
@@ -166,6 +176,11 @@ fn decode_3kib_reuse_buf(b: &mut Bencher) {
 }
 
 #[bench]
+fn decode_3kib_slice(b: &mut Bencher) {
+    do_decode_bench_slice(b, 3 * 1024)
+}
+
+#[bench]
 fn decode_3mib(b: &mut Bencher) {
     do_decode_bench(b, 3 * 1024 * 1024)
 }
@@ -173,6 +188,11 @@ fn decode_3mib(b: &mut Bencher) {
 #[bench]
 fn decode_3mib_reuse_buf(b: &mut Bencher) {
     do_decode_bench_reuse_buf(b, 3 * 1024 * 1024)
+}
+
+#[bench]
+fn decode_3mib_slice(b: &mut Bencher) {
+    do_decode_bench_slice(b, 3 * 1024 * 1024)
 }
 
 #[bench]
@@ -193,6 +213,11 @@ fn decode_30mib(b: &mut Bencher) {
 #[bench]
 fn decode_30mib_reuse_buf(b: &mut Bencher) {
     do_decode_bench_reuse_buf(b, 30 * 1024 * 1024)
+}
+
+#[bench]
+fn decode_30mib_slice(b: &mut Bencher) {
+    do_decode_bench_slice(b, 30 * 1024 * 1024)
 }
 
 fn do_decode_bench(b: &mut Bencher, size: usize) {
@@ -218,6 +243,20 @@ fn do_decode_bench_reuse_buf(b: &mut Bencher, size: usize) {
         decode_config_buf(&encoded, STANDARD, &mut buf).unwrap();
         test::black_box(&buf);
         buf.clear();
+    });
+}
+
+fn do_decode_bench_slice(b: &mut Bencher, size: usize) {
+    let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
+    fill(&mut v);
+    let encoded = encode(&v);
+
+    let mut buf = Vec::new();
+    buf.resize(size, 0);
+    b.bytes = encoded.len() as u64;
+    b.iter(|| {
+        decode_config_slice(&encoded, STANDARD, &mut buf).unwrap();
+        test::black_box(&buf);
     });
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -392,7 +392,7 @@ fn decode_helper(
         6 => 32,
         7 => 40,
         8 => 48,
-        _ => panic!(
+        _ => unreachable!(
             "Impossible: must only have 0 to 8 input bytes in last chunk, with no invalid lengths"
         ),
     };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -226,7 +226,7 @@ fn decode_helper(
         // If this is 3 unpadded chars, then it would actually decode to 2 bytes. However, if this
         // is an erroneous 2 chars + 1 pad char that would decode to 1 byte, then it should fail
         // with an error, not panic from going past the bounds of the output slice, so we let it
-        // use stage 3 + 4..
+        // use stage 3 + 4.
         3 => INPUT_CHUNK_LEN + 3,
         // This can also decode to one output byte because it may be 2 input chars + 2 padding
         // chars, which would decode to 1 byte.
@@ -382,7 +382,7 @@ fn decode_helper(
         let morsel = decode_table[*b as usize];
         if morsel == tables::INVALID_VALUE {
             return Err(DecodeError::InvalidByte(start_of_leftovers + i, *b));
-        };
+        }
 
         leftover_bits |= (morsel as u64) << shift;
         morsels_in_leftover += 1;

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,6 @@
 //! Enables base64'd output anywhere you might use a `Display` implementation, like a format string.
 //!
 //! ```
-//! use base64::STANDARD;
 //! use base64::display::Base64Display;
 //!
 //! let data = vec![0x0, 0x1, 0x2, 0x3];

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -528,14 +528,7 @@ mod tests {
 
             assert_eq!(prefix, encoded_data_with_prefix);
 
-            // since we know we have the correct count of line endings, it's reasonable to simply
-            // remove them without worrying about where they are
-            let encoded_no_line_endings: String = encoded_data_no_prefix
-                .chars()
-                .filter(|&c| c != '\r' && c != '\n')
-                .collect();
-
-            decode_config_buf(&encoded_no_line_endings, config, &mut decoded).unwrap();
+            decode_config_buf(&encoded_data_no_prefix, config, &mut decoded).unwrap();
             assert_eq!(orig_data, decoded);
         }
     }
@@ -591,17 +584,7 @@ mod tests {
                 &encoded_data_original_state[encoded_size..]
             );
 
-            // since we know we have the correct count of line endings, it's reasonable to simply
-            // remove them without worrying about where they are
-            let encoded_no_line_endings: String = String::from_utf8(
-                encoded_data[0..encoded_size]
-                    .iter()
-                    .filter(|&b| *b != '\r' as u8 && *b != '\n' as u8)
-                    .map(|&b| b)
-                    .collect(),
-            ).unwrap();
-
-            decode_config_buf(&encoded_no_line_endings, config, &mut decoded).unwrap();
+            decode_config_buf(&encoded_data[0..encoded_size], config, &mut decoded).unwrap();
             assert_eq!(orig_data, decoded);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod encode;
 pub use encode::{encode, encode_config, encode_config_buf, encode_config_slice};
 
 mod decode;
-pub use decode::{decode, decode_config, decode_config_buf, DecodeError};
+pub use decode::{decode, decode_config, decode_config_buf, decode_config_slice, DecodeError};
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,11 @@
 //! The functions that don't have `config` in the name (e.g. `encode()` and `decode()`) use the
 //! `STANDARD` config .
 //!
+//! The functions that write to a slice (the ones that end in `_slice`) are generally the fastest
+//! because they don't need to resize anything. If it fits in your workflow and you care about
+//! performance, keep using the same buffer (growing as need be) and use the `_slice` methods for
+//! the best performance.
+//!
 //! # Encoding
 //!
 //! Several different encoding functions are available to you depending on your desire for
@@ -26,22 +31,29 @@
 //!
 //! Just as for encoding, there are different decoding functions available.
 //!
+//! Note that all decode functions that take a config will allocate a copy of the input if you
+//! specify a config that requires whitespace to be stripped. If you care about speed, don't use
+//! formats that line wrap and then require whitespace stripping.
+//!
 //! | Function                | Output                        | Allocates                      |
 //! | ----------------------- | ----------------------------- | ------------------------------ |
 //! | `decode`                | Returns a new `Vec<u8>`       | Always                         |
 //! | `decode_config`         | Returns a new `Vec<u8>`       | Always                         |
 //! | `decode_config_buf`     | Appends to provided `Vec<u8>` | Only if `Vec` needs to grow    |
+//! | `decode_config_slice`   | Writes to provided `&[u8]`    | Never                          |
 //!
 //! Unlike encoding, where all possible input is valid, decoding can fail (see `DecodeError`).
 //!
 //! Input can be invalid because it has invalid characters or invalid padding. (No padding at all is
-//! valid, but incorrect padding is not.)
+//! valid, but excess padding is not.)
 //!
 //! Whitespace in the input is invalid unless `strip_whitespace` is enabled in the `Config` used.
 //!
 //! # Panics
 //!
 //! If length calculations result in overflowing `usize`, a panic will result.
+//!
+//! The `_slice` flavors of encode or decode will panic if the provided output slice is too small,
 
 #![deny(missing_docs, trivial_casts, trivial_numeric_casts, unused_extern_crates,
         unused_import_braces, unused_results, variant_size_differences, warnings)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -79,15 +79,9 @@ fn roundtrip_random_config(
 
         assert_encode_sanity(&encoded_buf, &config, input_len);
 
-        // remove line wrapping
-        let encoded_no_line_endings: String = encoded_buf
-            .chars()
-            .filter(|&c| c != '\r' && c != '\n')
-            .collect();
-
         assert_eq!(
             input_buf,
-            decode_config(&encoded_no_line_endings, config).unwrap()
+            decode_config(&encoded_buf, config).unwrap()
         );
     }
 }
@@ -113,5 +107,10 @@ pub fn random_config<R: Rng>(rng: &mut R, line_len_range: &Range<usize>) -> Conf
         CharacterSet::Standard
     };
 
-    Config::new(charset, rng.gen(), rng.gen(), line_wrap)
+    let strip_whitespace = match line_wrap {
+        LineWrap::NoWrap => false,
+        _ => true,
+    };
+
+    Config::new(charset, rng.gen(), strip_whitespace, line_wrap)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -79,10 +79,7 @@ fn roundtrip_random_config(
 
         assert_encode_sanity(&encoded_buf, &config, input_len);
 
-        assert_eq!(
-            input_buf,
-            decode_config(&encoded_buf, config).unwrap()
-        );
+        assert_eq!(input_buf, decode_config(&encoded_buf, config).unwrap());
     }
 }
 

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -120,6 +120,25 @@ fn decode_mime_absurd_whitespace() {
     );
 }
 
+#[test]
+fn decode_single_pad_byte_after_2_chars_in_trailing_quad_ok() {
+    for num_quads in 0..25 {
+        let mut s: String = std::iter::repeat("ABCD").take(num_quads).collect();
+        s.push_str("Zg=");
+
+        let input_len = num_quads * 3 + 1;
+
+        // Since there are 3 bytes in the trailing quad, want to be sure this allows for the fact
+        // that it could be bad padding rather than assuming that it will decode to 2 bytes and
+        // therefore allow 1 extra round of fast decode logic (stage 1 / 2).
+
+        let mut decoded = Vec::new();
+        decoded.resize(input_len, 0);
+
+        assert_eq!(input_len, decode_config_slice(&s, STANDARD, &mut decoded).unwrap());
+    }
+}
+
 //this is a MAY in the rfc: https://tools.ietf.org/html/rfc4648#section-3.3
 #[test]
 fn decode_1_pad_byte_in_fast_loop_then_extra_padding_chunk_error() {


### PR DESCRIPTION
Fixes #52.

This turned out to be quite a bit more work than I expected, but the results are pretty good I think.

First, a bcmp vs master:

```
 name                    control.bcmp ns/iter    branch.bcmp ns/iter     diff ns/iter   diff % 
 decode_100b             96 (1041 MB/s)          106 (943 MB/s)                    10   10.42% 
 decode_100b_reuse_buf   73 (1369 MB/s)          80 (1250 MB/s)                     7    9.59% 
 decode_10mib            7,852,829 (1335 MB/s)   7,098,399 (1477 MB/s)       -754,430   -9.61% 
 decode_10mib_reuse_buf  5,992,922 (1749 MB/s)   5,293,776 (1980 MB/s)       -699,146  -11.67% 
 decode_30mib            24,089,655 (1305 MB/s)  22,006,699 (1429 MB/s)    -2,082,956   -8.65% 
 decode_30mib_reuse_buf  18,534,301 (1697 MB/s)  16,336,266 (1925 MB/s)    -2,198,035  -11.86% 
 decode_3b               42 (95 MB/s)            79 (50 MB/s)                      37   88.10% 
 decode_3b_reuse_buf     24 (166 MB/s)           29 (137 MB/s)                      5   20.83% 
 decode_3kib             1,676 (1832 MB/s)       1,533 (2003 MB/s)               -143   -8.53% 
 decode_3kib_reuse_buf   1,673 (1836 MB/s)       1,500 (2048 MB/s)               -173  -10.34% 
 decode_3mib             2,225,701 (1413 MB/s)   2,045,099 (1538 MB/s)       -180,602   -8.11% 
 decode_3mib_reuse_buf   1,721,010 (1827 MB/s)   1,542,305 (2039 MB/s)       -178,705  -10.38% 
 decode_500b             307 (1628 MB/s)         291 (1718 MB/s)                  -16   -5.21% 
 decode_500b_reuse_buf   287 (1742 MB/s)         267 (1872 MB/s)                  -20   -6.97% 
 decode_50b              66 (787 MB/s)           75 (693 MB/s)                      9   13.64% 
 decode_50b_reuse_buf    46 (1130 MB/s)          54 (962 MB/s)                      8   17.39% 
```

Some regressions on extremely short inputs, but worth it for the speedups elsewhere. More good news on how well `decode_slice` does even compared to `master`'s performance on short inputs:

```
test decode_100b                ... bench:         106 ns/iter (+/- 6) = 943 MB/s
test decode_100b_reuse_buf      ... bench:          80 ns/iter (+/- 6) = 1250 MB/s
test decode_10mib               ... bench:   7,098,399 ns/iter (+/- 407,102) = 1477 MB/s
test decode_10mib_reuse_buf     ... bench:   5,293,776 ns/iter (+/- 858,381) = 1980 MB/s
test decode_30mib               ... bench:  22,006,699 ns/iter (+/- 733,699) = 1429 MB/s
test decode_30mib_reuse_buf     ... bench:  16,336,266 ns/iter (+/- 526,990) = 1925 MB/s
test decode_30mib_slice         ... bench:  14,875,003 ns/iter (+/- 547,959) = 2114 MB/s
test decode_3b                  ... bench:          79 ns/iter (+/- 2) = 50 MB/s
test decode_3b_reuse_buf        ... bench:          29 ns/iter (+/- 0) = 137 MB/s
test decode_3b_slice            ... bench:          18 ns/iter (+/- 0) = 222 MB/s
test decode_3kib                ... bench:       1,533 ns/iter (+/- 61) = 2003 MB/s
test decode_3kib_reuse_buf      ... bench:       1,500 ns/iter (+/- 47) = 2048 MB/s
test decode_3kib_slice          ... bench:       1,467 ns/iter (+/- 44) = 2094 MB/s
test decode_3mib                ... bench:   2,045,099 ns/iter (+/- 116,055) = 1538 MB/s
test decode_3mib_reuse_buf      ... bench:   1,542,305 ns/iter (+/- 49,346) = 2039 MB/s
test decode_3mib_slice          ... bench:   1,487,613 ns/iter (+/- 38,308) = 2114 MB/s
test decode_500b                ... bench:         291 ns/iter (+/- 9) = 1718 MB/s
test decode_500b_reuse_buf      ... bench:         267 ns/iter (+/- 9) = 1872 MB/s
test decode_50b                 ... bench:          75 ns/iter (+/- 1) = 693 MB/s
test decode_50b_reuse_buf       ... bench:          54 ns/iter (+/- 4) = 962 MB/s
test decode_50b_slice           ... bench:          43 ns/iter (+/- 1) = 1209 MB/s
```

Worst case on 3 byte decodes is a lot slower than `master`, but best case is a lot faster. On non-tiny inputs, 2GiB/s is finally attainable on my E5-1650v3.

At a high level, the logic changes were to rearrange the decode loops to never write garbage bytes past the end of what would eventually be overwritten with more decoded bytes. We used to get away with this because we could just `truncate()` the vec, but it seemed unacceptable to require the output buffer to be oversized by 2 bytes in some cases: users should be able to use an output buffer that's exactly the size of the decoded data.
