### PR TITLE
Change the suggested version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It's base64. What more could anyone want?
 Example
 ---
 
-In Cargo.toml: `base64 = "~0.6.0"`
+In Cargo.toml: `base64 = "~0.9.2"`
 
 ```rust
 extern crate base64;


### PR DESCRIPTION
The README was currently suggesting to install the 0.6 branch, which is now quite outdated.

It may be useful to add a note in your release process to not forget to update this example.