### PR TITLE
Fix `cargo doc` breaks on latest rust 1.28.0-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Alice Maz <alice@alicemaz.com>", "Marshall Pierce <marshall@mpierce.org>"]
 description = "encodes and decodes base64 as bytes or utf8"
 repository = "https://github.com/alicemaz/rust-base64"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,11 @@
 
 #![deny(
     missing_docs, trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_results, variant_size_differences, warnings
+    unused_results, variant_size_differences, 
 )]
 
 extern crate byteorder;
+extern crate safemem;
 
 mod chunked_encoder;
 pub mod display;

--- a/src/line_wrap.rs
+++ b/src/line_wrap.rs
@@ -1,6 +1,6 @@
-extern crate safemem;
-
 use super::*;
+use safemem;
+
 
 #[derive(Debug, PartialEq)]
 pub struct LineWrapParameters {


### PR DESCRIPTION
This addresses #64

I'm unsure if this is right. 