### PR TITLE
Add config for travis-ci with cargo-tarpaulin test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+---
+language: rust
+dist: trusty
+sudo: required
+
+matrix:
+  include:
+    - rust: 1.23.0
+    - rust: stable
+      addons:
+        apt:
+          packages:
+            # cargo-tarpaulin needs this
+            - libssl-dev
+      install:
+        # For test coverage. In install step so that it can use cache.
+        - cargo tarpaulin --version || RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+    - rust: beta
+    - rust: nightly
+  allow_failures:
+    - rust: nightly
+
+cache: cargo
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo doc --verbose
+  - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo bench --no-run; fi'
+
+after_success: |
+  if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then
+    # Calculate test coverage
+    cargo tarpaulin --out Xml
+    bash <(curl -s https://codecov.io/bash)
+  fi


### PR DESCRIPTION
* Builds on 1.23, stable, beta and nightly (nightly allowed to fail)
* Compiles, runs tests, builds docs and compiles benches
* Uses [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) for coverage and uploads to codecov.io, see here for the results from my fork: https://codecov.io/gh/robinst/rust-base64/tree/add-travis-ci/src

Fixes #68. 