### PR TITLE
Use sha2 crate

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 rand = "0.6.1"
 rand_pcg = "0.1.1"
-ring = "0.13.5"
+sha2 = "0.7"
 [dependencies.base64]
 path = ".."
 [dependencies.libfuzzer-sys]

--- a/fuzz/fuzzers/utils.rs
+++ b/fuzz/fuzzers/utils.rs
@@ -15,7 +15,7 @@ pub fn random_config(data: &[u8]) -> Config {
     let mut seed: [u8; 16] = [0; 16];
     seed.copy_from_slice(&sha[..16]);
 
-    let mut rng = Pcg32::from_seed(&sha);
+    let mut rng = Pcg32::from_seed(seed);
 
     let charset = if rng.gen() {
         CharacterSet::UrlSafe

--- a/fuzz/fuzzers/utils.rs
+++ b/fuzz/fuzzers/utils.rs
@@ -1,21 +1,21 @@
 extern crate base64;
 extern crate rand;
 extern crate rand_pcg;
-extern crate ring;
+extern crate sha2;
 
 use self::base64::*;
 use self::rand::{Rng, SeedableRng};
 use self::rand_pcg::Pcg32;
-use self::ring::digest;
+use self::sha2::{Sha256, Digest};
 
 pub fn random_config(data: &[u8]) -> Config {
     // use sha256 of data as rng seed so it's repeatable
-    let sha = digest::digest(&digest::SHA256, data);
+    let sha = Sha256::digest(data);
 
     let mut seed: [u8; 16] = [0; 16];
-    seed.copy_from_slice(&sha.as_ref()[0..16]);
+    seed.copy_from_slice(&sha[..16]);
 
-    let mut rng = Pcg32::from_seed(seed);
+    let mut rng = Pcg32::from_seed(&sha);
 
     let charset = if rng.gen() {
         CharacterSet::UrlSafe


### PR DESCRIPTION
Using `ring` for a single SHA-256 function is certainly an overkill.

BTW running `cargo check` on `fuzz` crate produces the following error:
```
error[E0061]: this function takes 2 parameters but 3 parameters were supplied
 --> fuzzers/roundtrip_no_pad.rs:6:18
  |
6 |     let config = base64::Config::new(base64::CharacterSet::Standard, false, false);
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 2 parameters

```