### PR TITLE
Add no_std support using alloc if std feature is disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc --verbose
+  - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo build --no-default-features --verbose; fi'
+  - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo test --no-default-features --verbose; fi'
   - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo bench --no-run; fi'
   # run for just a second to confirm that it can build and run ok
   - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo fuzz list | xargs -L 1 -I FUZZER cargo fuzz run FUZZER -- -max_total_time=1; fi'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ criterion = "0.2"
 rand = "0.6.1"
 doc-comment = "0.3"
 
+[features]
+default = ["std"]
+std = []
+
 [profile.bench]
 # Useful for better disassembly when using `perf record` and `perf annotate`
 debug = true

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,6 +1,6 @@
 use {String, Config};
 use encode::{add_padding, encode_to_slice};
-use core::cmp;
+use core::{cmp,str};
 
 /// The output mechanism for ChunkedEncoder's encoded bytes.
 pub trait Sink {
@@ -92,7 +92,7 @@ impl<'a> Sink for StringSink<'a> {
     type Error = ();
 
     fn write_encoded_bytes(&mut self, s: &[u8]) -> Result<(), Self::Error> {
-        self.string.push_str(core::str::from_utf8(s).unwrap());
+        self.string.push_str(str::from_utf8(s).unwrap());
 
         Ok(())
     }

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,6 +1,6 @@
+use crate::{String, Config};
 use encode::{add_padding, encode_to_slice};
-use std::{cmp, str};
-use Config;
+use core::cmp;
 
 /// The output mechanism for ChunkedEncoder's encoded bytes.
 pub trait Sink {
@@ -92,7 +92,7 @@ impl<'a> Sink for StringSink<'a> {
     type Error = ();
 
     fn write_encoded_bytes(&mut self, s: &[u8]) -> Result<(), Self::Error> {
-        self.string.push_str(str::from_utf8(s).unwrap());
+        self.string.push_str(core::str::from_utf8(s).unwrap());
 
         Ok(())
     }

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,4 +1,4 @@
-use crate::{String, Config};
+use {String, Config};
 use encode::{add_padding, encode_to_slice};
 use core::cmp;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,9 @@
+use crate::{Vec, tables, Config, STANDARD};
 use byteorder::{BigEndian, ByteOrder};
-use {tables, Config, STANDARD};
 
-use std::{error, fmt, str};
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error;
 
 // decode logic operates on chunks of 8 input bytes without padding
 const INPUT_CHUNK_LEN: usize = 8;
@@ -46,6 +48,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for DecodeError {
     fn description(&self) -> &str {
         match *self {
@@ -543,6 +546,7 @@ fn decode_chunk_precise(
 mod tests {
     extern crate rand;
 
+    use crate::String;
     use super::*;
     use encode::encode_config_buf;
     use tests::{assert_encode_sanity, random_config};
@@ -758,6 +762,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn detect_invalid_last_symbol_every_possible_three_symbols() {
         let mut base64_to_bytes = ::std::collections::HashMap::new();
 
@@ -768,7 +773,7 @@ mod tests {
                 bytes[1] = b2 as u8;
                 let mut b64 = vec![0_u8; 4];
                 assert_eq!(4, ::encode_config_slice(&bytes, STANDARD, &mut b64[..]));
-                let mut v = ::std::vec::Vec::with_capacity(2);
+                let mut v = Vec::with_capacity(2);
                 v.extend_from_slice(&bytes[..]);
 
                 assert!(base64_to_bytes.insert(b64, v).is_none());
@@ -801,13 +806,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn detect_invalid_last_symbol_every_possible_two_symbols() {
         let mut base64_to_bytes = ::std::collections::HashMap::new();
 
         for b in 0_u16..256 {
             let mut b64 = vec![0_u8; 4];
             assert_eq!(4, ::encode_config_slice(&[b as u8], STANDARD, &mut b64[..]));
-            let mut v = ::std::vec::Vec::with_capacity(1);
+            let mut v = Vec::with_capacity(1);
             v.push(b as u8);
 
             assert!(base64_to_bytes.insert(b64, v).is_none());

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,4 @@
-use crate::{Vec, tables, Config, STANDARD};
+use {Vec, tables, Config, STANDARD};
 use byteorder::{BigEndian, ByteOrder};
 
 use core::fmt;
@@ -546,7 +546,7 @@ fn decode_chunk_precise(
 mod tests {
     extern crate rand;
 
-    use crate::String;
+    use String;
     use super::*;
     use encode::encode_config_buf;
     use tests::{assert_encode_sanity, random_config};

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,8 +11,8 @@
 
 use super::chunked_encoder::ChunkedEncoder;
 use super::Config;
-use std::fmt::{Display, Formatter};
-use std::{fmt, str};
+use core::fmt::{Display, Formatter};
+use core::{fmt, str};
 
 /// A convenience wrapper for base64'ing bytes into a format string without heap allocation.
 pub struct Base64Display<'a> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -323,7 +323,7 @@ mod tests {
 
     use self::rand::distributions::{Distribution, Uniform};
     use self::rand::{FromEntropy, Rng};
-    use core::str;
+    use core::{usize, str};
 
     #[test]
     fn encoded_size_correct_standard() {
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn encoded_size_overflow() {
-        assert_eq!(None, encoded_size(core::usize::MAX, STANDARD));
+        assert_eq!(None, encoded_size(usize::MAX, STANDARD));
     }
 
     #[test]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,4 +1,4 @@
-use crate::{String, Config, STANDARD};
+use {String, Config, STANDARD};
 use byteorder::{BigEndian, ByteOrder};
 
 ///Encode arbitrary octets as base64.
@@ -316,7 +316,7 @@ pub fn add_padding(input_len: usize, output: &mut [u8]) -> usize {
 mod tests {
     extern crate rand;
 
-    use crate::{Vec, URL_SAFE_NO_PAD};
+    use {Vec, URL_SAFE_NO_PAD};
     use super::*;
     use decode::decode_config_buf;
     use tests::{assert_encode_sanity, random_config};

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,5 +1,5 @@
+use crate::{String, Config, STANDARD};
 use byteorder::{BigEndian, ByteOrder};
-use {Config, STANDARD};
 
 ///Encode arbitrary octets as base64.
 ///Returns a String.
@@ -316,15 +316,14 @@ pub fn add_padding(input_len: usize, output: &mut [u8]) -> usize {
 mod tests {
     extern crate rand;
 
+    use crate::{Vec, URL_SAFE_NO_PAD};
     use super::*;
     use decode::decode_config_buf;
     use tests::{assert_encode_sanity, random_config};
-    use {Config, STANDARD, URL_SAFE_NO_PAD};
 
     use self::rand::distributions::{Distribution, Uniform};
     use self::rand::{FromEntropy, Rng};
-    use std;
-    use std::str;
+    use core::str;
 
     #[test]
     fn encoded_size_correct_standard() {
@@ -378,7 +377,7 @@ mod tests {
 
     #[test]
     fn encoded_size_overflow() {
-        assert_eq!(None, encoded_size(std::usize::MAX, STANDARD));
+        assert_eq!(None, encoded_size(core::usize::MAX, STANDARD));
     }
 
     #[test]
@@ -476,7 +475,7 @@ mod tests {
             );
 
             assert_encode_sanity(
-                std::str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
+                str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
                 config,
                 input_len,
             );
@@ -524,7 +523,7 @@ mod tests {
             );
 
             assert_encode_sanity(
-                std::str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
+                str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
                 config,
                 input_len,
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
     unsafe_code
 )]
 
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,25 @@
     unsafe_code
 )]
 
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+#![no_std]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(feature = "std")]
+use std::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 extern crate byteorder;
 #[cfg(test)]
 #[macro_use]
@@ -73,6 +92,7 @@ doctest!("../README.md");
 mod chunked_encoder;
 pub mod display;
 mod tables;
+#[cfg(feature = "std")]
 pub mod write;
 
 mod encode;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,8 @@
 extern crate rand;
 
+use crate::*;
 use encode::encoded_size;
-use *;
-
-use std::str;
+use core::str;
 
 use self::rand::distributions::{Distribution, Uniform};
 use self::rand::{FromEntropy, Rng};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 
-use crate::*;
+use *;
 use encode::encoded_size;
 use core::str;
 

--- a/src/write/encoder_tests.rs
+++ b/src/write/encoder_tests.rs
@@ -1,5 +1,6 @@
 extern crate rand;
 
+use crate::{String, Vec};
 use super::EncoderWriter;
 use tests::random_config;
 use {encode_config, encode_config_buf, STANDARD_NO_PAD, URL_SAFE};

--- a/src/write/encoder_tests.rs
+++ b/src/write/encoder_tests.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 
-use crate::{String, Vec};
+use {String, Vec};
 use super::EncoderWriter;
 use tests::random_config;
 use {encode_config, encode_config_buf, STANDARD_NO_PAD, URL_SAFE};


### PR DESCRIPTION
Tried to minimize code impact by not adding pure `no_std`. `no_std` with `alloc` should still be very useful.