### PR TITLE
Remove the byteorder dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ license = "MIT/Apache-2.0"
 name = "benchmarks"
 harness = false
 
-[dependencies]
-byteorder = "1.2.6"
-
 [dev-dependencies]
 criterion = "0.2"
 rand = "0.6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
     unsafe_code
 )]
 
-extern crate byteorder;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;


### PR DESCRIPTION
I understand that this is a controversial change and you do not want any `unsafe` in your library. But there are no benefits in "hiding" an `unsafe` in `byteorder`. So by using the same code directly, we will not make the `base64` less safe.

On the bright side, we are reducing the build time by 2.5x. Which is very important for a such widely used library.

```sh
# before
> hyperfine 'cargo clean; cargo build --release'
  Time (mean ± σ):      1.729 s ±  0.006 s    [User: 2.570 s, System: 0.137 s]
  Range (min … max):    1.718 s …  1.737 s    10 runs
# after
> hyperfine 'cargo clean; cargo build --release'
  Time (mean ± σ):     657.2 ms ±  15.8 ms    [User: 861.8 ms, System: 62.5 ms]
  Range (min … max):   644.8 ms … 697.0 ms    10 runs
```